### PR TITLE
refactoring_bug_fixes

### DIFF
--- a/include/all.hxx
+++ b/include/all.hxx
@@ -118,7 +118,7 @@ struct lgar_bmi_parameters
   int    num_soil_types;           // number of soil types; must be less than or equal to MAX_NUM_SOIL_TYPES
   double AET_cm;                   // actual evapotranspiration in cm
 
-  double *soil_moisture_layers;    // 1D array of thetas (mean soil moisture content) per layer; output option to other models if needed
+  //double *soil_moisture_layers;    // 1D array of thetas (mean soil moisture content) per layer; output option to other models if needed
   double *soil_moisture_wetting_fronts; /* 1D array of thetas (soil moisture content) per wetting front;
 					   output to other models (e.g. soil freeze-thaw) */
   double *soil_depth_wetting_fronts;    /* 1D array of absolute depths of the wetting fronts [meters];
@@ -220,8 +220,7 @@ extern void                     listInsertFirst(double d, double t, int f, int l
 extern struct wetting_front*    listInsertFront(double d, double t, int f, int l, bool b, struct wetting_front** head);
 extern struct wetting_front*    listInsertFrontAtDepth(int numlay, double *tvec,double d, double t, struct wetting_front* head);
 extern void                     listReverseOrder(struct wetting_front** head_ref);
-extern bool                     listFindLayer(struct wetting_front* link, int num_layers,
-					      double *cum_layer_thickness_cm,
+extern bool                     listFindLayer(struct wetting_front* link, int num_layers, double *cum_layer_thickness_cm,
 					      int *lives_in_layer, bool *extends_to_bottom_flag);
 extern struct wetting_front*    listCopy(struct wetting_front* current, struct wetting_front* state_previous=NULL);
 

--- a/include/all.hxx
+++ b/include/all.hxx
@@ -288,7 +288,7 @@ extern void lgar_wetting_fronts_cross_layer_boundary(int num_layers, double* cum
 /* the subroutine allows the deepest wetting front to partially leave the model through the lower boundary if necessary;
    called from lgar_move_wetting_fronts. Currently, fluxes from the lower boundary will always be 0 and this fraction of a
    wetting front will be dealth with in another way */
-extern double lgar_wetting_front_cross_domain_boundary(double* cum_layer_thickness_cm, int *soil_type, double *frozen_factor,
+extern double lgar_wetting_front_cross_domain_boundary(double domain_depth_cm, int *soil_type, double *frozen_factor,
 						       struct wetting_front** head, struct soil_properties_ *soil_properties);
 
 // subroutine to handle wet over dry wetting fronts condtions

--- a/include/all.hxx
+++ b/include/all.hxx
@@ -60,7 +60,6 @@ struct wetting_front
    in subroutines a pain of referencing.  Since it is just one thing,
    making it global just makes everything easier.
 */
-extern struct wetting_front *head;
 
 
 // Define a data structure to hold properties and parameters for each soil type
@@ -185,12 +184,15 @@ struct lgar_mass_balance_variables
 // nested structure of structures; main structure for the use in bmi
 struct model_state
 {
-  struct wetting_front wetting_front;
-  struct soil_properties_* soil_properties; // dynamic allocation
-  struct lgar_bmi_parameters lgar_bmi_params;
-  struct lgar_mass_balance_variables lgar_mass_balance;
-  struct unit_conversion units;
-  struct lgar_bmi_input_parameters* lgar_bmi_input_params;
+  //  struct wetting_front wetting_front;
+  struct wetting_front*               head           = NULL; // head pointer to the current state
+  struct wetting_front*               state_previous = NULL; // head pointer to the previous state,
+                                                             // used in computing derivatives and mass balance
+  struct soil_properties_*            soil_properties;       // dynamic allocation
+  struct lgar_bmi_parameters          lgar_bmi_params;
+  struct lgar_mass_balance_variables  lgar_mass_balance;
+  struct unit_conversion              units;
+  struct lgar_bmi_input_parameters*   lgar_bmi_input_params;
 };
 
 
@@ -207,26 +209,25 @@ struct model_state
 // inside parentheses are the types of require arguments, names don't matter
 
 
-extern void                     listPrint();
-extern void                     listPrintC(struct wetting_front pcurrent);
-extern int                      listLength();
+extern void                     listPrint(struct wetting_front* head);
+extern int                      listLength(struct wetting_front* head);
 extern bool                     listIsEmpty();
-extern struct wetting_front*    listDeleteFirst();
-extern struct wetting_front*    listFindFront(int i,struct wetting_front* head_old);
-extern struct wetting_front*    listDeleteFront(int i);
-extern void                     listSortFrontsByDepth();
-extern void                     listInsertFirst(double d, double t, int f, int l, bool b);
-extern struct wetting_front*    listInsertFront(double d, double t, int f, int l, bool b);
-extern struct wetting_front*    listInsertFrontAtDepth(int numlay, double *tvec,double d, double t);
+extern struct wetting_front*    listDeleteFirst(struct wetting_front** head);
+extern struct wetting_front*    listFindFront(int i, struct wetting_front* head, struct wetting_front* head_old);
+extern struct wetting_front*    listDeleteFront(int i, struct wetting_front** head);
+extern void                     listSortFrontsByDepth(struct wetting_front *head);
+extern void                     listInsertFirst(double d, double t, int f, int l, bool b, struct wetting_front** head);
+extern struct wetting_front*    listInsertFront(double d, double t, int f, int l, bool b, struct wetting_front** head);
+extern struct wetting_front*    listInsertFrontAtDepth(int numlay, double *tvec,double d, double t, struct wetting_front* head);
 extern void                     listReverseOrder(struct wetting_front** head_ref);
 extern bool                     listFindLayer(struct wetting_front* link, int num_layers,
-                                               double *cum_layer_thickness_cm,
-                                               int *lives_in_layer, bool *extends_to_bottom_flag);
-extern struct wetting_front*    listCopy(struct wetting_front* current);
+					      double *cum_layer_thickness_cm,
+					      int *lives_in_layer, bool *extends_to_bottom_flag);
+extern struct wetting_front*    listCopy(struct wetting_front* current, struct wetting_front* state_previous=NULL);
 
 
-// head pointer to the previous state/timestep, used in computing derivatives and mass balance
-extern struct wetting_front *state_previous;
+
+
 
 /*########################################*/
 /*   van Genuchten function prototypes    */
@@ -244,55 +245,57 @@ extern double calc_Geff(bool use_closed_form_G, double theta1, double theta2, do
 /* LGAR calculation function prototypes   */
 /*########################################*/
 // computed mass balance
-extern double lgar_calc_mass_bal(double *cum_layer_thickness);
+extern double lgar_calc_mass_bal(double *cum_layer_thickness, struct wetting_front* head);
 
 // computes derivatives; called derivs() in Python code
 extern void lgar_dzdt_calc(bool use_closed_form_G, int nint, double h_p, int *soil_type, double *cum_layer_thickness,
-			   double *frozen_factor, struct soil_properties_ *soil_properties);
+			   double *frozen_factor, struct wetting_front* head, struct soil_properties_ *soil_properties);
 
 // computes dry depth
 extern double lgar_calc_dry_depth(bool use_closed_form_G, int nint, double timestep_h, double *deltheta, int *soil_type,
                                   double *cum_layer_thickness_cm, double *frozen_factor,
-				  struct soil_properties_ *soil_properties);
+				  struct wetting_front* head, struct soil_properties_ *soil_properties);
 
 // reads van Genuchten parameters from a file
 extern int lgar_read_vG_param_file(char const* vG_param_file_name, int num_soil_types, double wilting_point_psi_cm,
                                     struct soil_properties_ *soil_properties);
 
 // creates a surficial front (new top most wetting front)
-extern void lgar_create_surfacial_front(double *ponded_depth_cm, double *volin, double dry_depth,
+extern void lgar_create_surficial_front(double *ponded_depth_cm, double *volin, double dry_depth,
 					double theta1, int *soil_type, double *cum_layer_thickness_cm,
-					double *frozen_factor, struct soil_properties_ *soil_properties);
+					double *frozen_factor, struct wetting_front **head, struct soil_properties_ *soil_properties);
 
 // computes the infiltration capacity, fp, of the soil
 extern double lgar_insert_water(bool use_closed_form_G, int nint, double timestep_h, double *ponded_depth,
 				double *volin_this_timestep, double precip_timestep_cm, int wf_free_drainge_demand,
 				int num_layers, double ponded_depth_max_cm, int *soil_type, double *cum_layer_thickness_cm,
-				double *frozen_factor, struct soil_properties_ *soil_properties);
+				double *frozen_factor, struct wetting_front* head, struct soil_properties_ *soil_properties);
 
 // the subroutine moves wetting fronts, merges wetting fronts, and does the mass balance correction if needed
 extern void lgar_move_wetting_fronts(double timestep_h, double *ponded_depth_cm, int wf_free_drainage_demand,
 				     double old_mass, int number_of_layers, double *actual_ET_demand,
 				     double *cum_layer_thickness_cm, int *soil_type_by_layer, double *frozen_factor,
-				     struct soil_properties_ *soil_properties);
+				     struct wetting_front** head, struct wetting_front* state_previous, struct soil_properties_ *soil_properties);
 
 // the subroutine merges the wetting fronts; called from lgar_move_wetting_fronts
-extern void lgar_merge_wetting_fronts(int *soil_type, double *frozen_factor, struct soil_properties_ *soil_properties);
+extern void lgar_merge_wetting_fronts(int *soil_type, double *frozen_factor, struct wetting_front** head,
+				      struct soil_properties_ *soil_properties);
 
 // the subroutine lets wetting fronts cross soil layer boundaries; called from lgar_move_wetting_fronts
 extern void lgar_wetting_fronts_cross_layer_boundary(int num_layers, double* cum_layer_thickness_cm,
-					int *soil_type, double *frozen_factor, struct soil_properties_ *soil_properties);
+						     int *soil_type, double *frozen_factor, struct wetting_front** head,
+						     struct soil_properties_ *soil_properties);
 
 // the subroutine allows the deepest wetting front to partially leave the model through the lower boundary if necessary; called from lgar_move_wetting_fronts. Currently, fluxes from the lower boundary will always be 0 and this fraction of a wetting front will be dealth with in another way
 extern double lgar_wetting_front_cross_domain_boundary(double* cum_layer_thickness_cm, int *soil_type, double *frozen_factor,
-						       struct soil_properties_ *soil_properties);
+						       struct wetting_front** head, struct soil_properties_ *soil_properties);
 
 // subroutine to handle wet over dry wetting fronts condtions
 extern void lgar_fix_dry_over_wet_fronts(double *mass_change, double* cum_layer_thickness_cm, int *soil_type,
-					 struct soil_properties_ *soil_properties);
+					 struct wetting_front** head, struct soil_properties_ *soil_properties);
 
 // finds free drainage wetting front (the deepest wetting front with psi value closer to zero; saturated in terms of psi)
-extern int wetting_front_free_drainage();
+extern int wetting_front_free_drainage(struct wetting_front* head);
 
 // computes updated theta (soil moisture content) after moving down a wetting front; called for each wetting front to ensure mass is conserved
 extern double lgar_theta_mass_balance(int layer_num, int soil_num, double psi_cm, double new_mass,
@@ -307,14 +310,14 @@ extern void lgar_initialize(string config_file, struct model_state *state);
 extern void InitFromConfigFile(string config_file, struct model_state *state);
 extern vector<double> ReadVectorData(string key);
 extern void InitializeWettingFronts(int num_layers, double initial_psi_cm, int *layer_soil_type, double *cum_layer_thickness_cm,
-				    double *frozen_factor, struct soil_properties_ *soil_properties);
+				    double *frozen_factor, struct wetting_front** head, struct soil_properties_ *soil_properties);
 
 /********************************************************************/
 /*Other function prototypes for doing hydrology calculations, etc.  */
 /********************************************************************/
 
 extern double calc_aet(double PET_timestep_cm, double timestep_h, double wilting_point_psi_cm, int *soil_type,
-		       double AET_thresh_Theta, double AET_expon, struct soil_properties_ *soil_props);
+		       double AET_thresh_Theta, double AET_expon, struct wetting_front* head, struct soil_properties_ *soil_props);
 
 /********************************************************************/
 /* Input/Output functions, etc.  */
@@ -324,7 +327,7 @@ extern double calc_aet(double PET_timestep_cm, double timestep_h, double wilting
 extern void lgar_global_mass_balance(struct model_state *state, double *giuh_runoff_queue);
 
 // writes full state of wetting fronts (depth, theta, no. of wetting front, no. of layer, dz/dt, psi) to a file at each time step
-extern void write_state(FILE *out);
+extern void write_state(FILE *out, struct wetting_front* head);
 
 
 /********************************************************************/
@@ -337,8 +340,8 @@ extern void frozen_factor_hydraulic_conductivity(struct lgar_bmi_parameters lgar
 /*###################################################################*/
 /*   1- and 2-D int and double memory allocation function prototypes */
 /*###################################################################*/
-extern void itwo_alloc( int ***ptr, int x, int y);
-extern void dtwo_alloc( double ***ptr, int x, int y);
+extern void itwo_alloc(int ***ptr, int x, int y);
+extern void dtwo_alloc(double ***ptr, int x, int y);
 extern void d_alloc(double **var,int size);
 extern void i_alloc(int **var,int size);
 extern void f_alloc(float **var,int size);

--- a/include/all.hxx
+++ b/include/all.hxx
@@ -285,13 +285,18 @@ extern void lgar_wetting_fronts_cross_layer_boundary(int num_layers, double* cum
 						     int *soil_type, double *frozen_factor, struct wetting_front** head,
 						     struct soil_properties_ *soil_properties);
 
-// the subroutine allows the deepest wetting front to partially leave the model through the lower boundary if necessary; called from lgar_move_wetting_fronts. Currently, fluxes from the lower boundary will always be 0 and this fraction of a wetting front will be dealth with in another way
+/* the subroutine allows the deepest wetting front to partially leave the model through the lower boundary if necessary;
+   called from lgar_move_wetting_fronts. Currently, fluxes from the lower boundary will always be 0 and this fraction of a
+   wetting front will be dealth with in another way */
 extern double lgar_wetting_front_cross_domain_boundary(double* cum_layer_thickness_cm, int *soil_type, double *frozen_factor,
 						       struct wetting_front** head, struct soil_properties_ *soil_properties);
 
 // subroutine to handle wet over dry wetting fronts condtions
-extern void lgar_fix_dry_over_wet_fronts(double *mass_change, double* cum_layer_thickness_cm, int *soil_type,
-					 struct wetting_front** head, struct soil_properties_ *soil_properties);
+extern void lgar_fix_dry_over_wet_wetting_fronts(double *mass_change, double* cum_layer_thickness_cm, int *soil_type,
+						 struct wetting_front** head, struct soil_properties_ *soil_properties);
+
+// checks if dry over wet wetting front exists or not
+extern bool lgar_check_dry_over_wet_wetting_fronts(struct wetting_front* head);
 
 // finds free drainage wetting front (the deepest wetting front with psi value closer to zero; saturated in terms of psi)
 extern int wetting_front_free_drainage(struct wetting_front* head);

--- a/include/bmi_lgar.hxx
+++ b/include/bmi_lgar.hxx
@@ -34,24 +34,23 @@ public:
     this->input_var_names[1] = "potential_evapotranspiration_rate";
     this->input_var_names[2] = "soil_temperature_profile";
     
-    this->output_var_names[0] = "soil_moisture_layers";
-    this->output_var_names[1] = "soil_moisture_wetting_fronts";
-    this->output_var_names[2] = "soil_thickness_layers";
-    this->output_var_names[3] = "soil_depth_wetting_fronts";
-    this->output_var_names[4] = "soil_num_wetting_fronts";
+    this->output_var_names[0] = "soil_moisture_wetting_fronts";
+    this->output_var_names[1] = "soil_depth_layers";
+    this->output_var_names[2] = "soil_depth_wetting_fronts";
+    this->output_var_names[3] = "soil_num_wetting_fronts";
     
     // vis outputs
-    this->output_var_names[5]  = "precipitation";
-    this->output_var_names[6]  = "potential_evapotranspiration";
-    this->output_var_names[7]  = "actual_evapotranspiration";
-    this->output_var_names[8]  = "surface_runoff"; // direct surface runoff
-    this->output_var_names[9]  = "giuh_runoff";
-    this->output_var_names[10] = "soil_storage";
-    this->output_var_names[11] = "total_discharge";
-    this->output_var_names[12] = "infiltration";
-    this->output_var_names[13] = "percolation";
-    this->output_var_names[14] = "groundwater_to_stream_recharge";
-    this->output_var_names[15] = "mass_balance";
+    this->output_var_names[4]  = "precipitation";
+    this->output_var_names[5]  = "potential_evapotranspiration";
+    this->output_var_names[6]  = "actual_evapotranspiration";
+    this->output_var_names[7]  = "surface_runoff"; // direct surface runoff
+    this->output_var_names[8]  = "giuh_runoff";
+    this->output_var_names[9]  = "soil_storage";
+    this->output_var_names[10] = "total_discharge";
+    this->output_var_names[11] = "infiltration";
+    this->output_var_names[12] = "percolation";
+    this->output_var_names[13] = "groundwater_to_stream_recharge";
+    this->output_var_names[14] = "mass_balance";
     
     /*
     this->output_var_names[13] = "cum_precipitation";
@@ -124,7 +123,7 @@ public:
 private:
   struct model_state* state;
   static const int input_var_name_count = 3;
-  static const int output_var_name_count = 16;
+  static const int output_var_name_count = 15;
   
   std::string input_var_names[input_var_name_count];
   std::string output_var_names[output_var_name_count];

--- a/src/aet.cxx
+++ b/src/aet.cxx
@@ -16,7 +16,7 @@
 
 extern double calc_aet(double PET_timestep_cm, double time_step_h, double wilting_point_psi_cm,
 		       int *soil_type, double AET_thresh_Theta, double AET_expon,
-		       struct soil_properties_ *soil_properties)
+		       struct wetting_front* head, struct soil_properties_ *soil_properties)
 {
 
   if (verbosity.compare("high") == 0) {

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -344,7 +344,7 @@ Update()
     }
 
     bool unexpected_local_error = fabs(local_mb) > 1.0E-6 ? true : false;
-
+    
     if (verbosity.compare("high") == 0 || verbosity.compare("low") == 0 || unexpected_local_error) {
       printf("\nLocal mass balance at this timestep... \n\
       Error         = %14.10f \n\
@@ -403,7 +403,7 @@ Update()
 	       <<state->lgar_bmi_params.soil_depth_wetting_fronts[i]
 	       <<" "<<state->lgar_bmi_params.soil_moisture_wetting_fronts[i]<<"\n";
   }
-
+  
   // add to mass balance timestep variables
   state->lgar_mass_balance.volprecip_timestep_cm  = precip_timestep_cm;
   state->lgar_mass_balance.volin_timestep_cm      = volin_timestep_cm;
@@ -442,6 +442,7 @@ Update()
   bmi_unit_conv.volQ_gw_timestep_m    = volQ_gw_timestep_cm * state->units.cm_to_m;
   bmi_unit_conv.volPET_timestep_m     = PET_timestep_cm * state->units.cm_to_m;
   bmi_unit_conv.volrunoff_giuh_timestep_m = volrunoff_giuh_timestep_cm * state->units.cm_to_m;
+  
 }
 
 
@@ -489,7 +490,7 @@ GetVarGrid(std::string name)
     return 1;
   else if (name.compare("mass_balance") == 0)
     return 1;
-  else if (name.compare("soil_moisture_layers") == 0 || name.compare("soil_thickness_layers") == 0) // array of doubles (fixed length)
+  else if (name.compare("soil_depth_layers") == 0) // array of doubles (fixed length)
     return 2;
   else if (name.compare("soil_moisture_wetting_fronts") == 0 || name.compare("soil_depth_wetting_fronts") == 0) // array of doubles (dynamic length)
     return 3;
@@ -544,9 +545,9 @@ GetVarUnits(std::string name)
     return "m";
   else if (name.compare("mass_balance") == 0 || name.compare("groundwater_to_stream_recharge") == 0)
     return "m";
-  else if (name.compare("soil_moisture_layers") == 0 || name.compare("soil_moisture_wetting_fronts") == 0) // array of doubles
+  else if (name.compare("soil_moisture_wetting_fronts") == 0) // array of doubles
     return "none";
-  else if (name.compare("soil_thickness_layers") == 0 || name.compare("soil_depth_wetting_fronts") == 0) // array of doubles
+  else if (name.compare("soil_depth_layers") == 0 || name.compare("soil_depth_wetting_fronts") == 0) // array of doubles
     return "m";
   else if (name.compare("soil_temperature_profile") == 0)
     return "K";
@@ -581,11 +582,11 @@ GetVarLocation(std::string name)
    else if (name.compare("total_discharge") == 0 || name.compare("infiltration") == 0
 	    || name.compare("percolation") == 0 || name.compare("groundwater_to_stream_recharge") == 0) // double
     return "node";
-  else if (name.compare("soil_moisture_layers") == 0 || name.compare("soil_moisture_wetting_fronts") == 0) // array of doubles
+  else if (name.compare("soil_moisture_wetting_fronts") == 0) // array of doubles
     return "node";
   else if (name.compare("mass_balance") == 0)
     return "node";
-  else if (name.compare("soil_thickness_layers") == 0 || name.compare("soil_depth_wetting_fronts") == 0
+  else if (name.compare("soil_depth_layers") == 0 || name.compare("soil_depth_wetting_fronts") == 0
 	   || name.compare("soil_num_wetting_fronts") == 0) // array of doubles
     return "node";
   else if (name.compare("soil_temperature_profile") == 0)
@@ -691,10 +692,8 @@ GetValuePtr (std::string name)
     return (void*)(&bmi_unit_conv.volQ_gw_timestep_m);
   else if (name.compare("mass_balance") == 0)
     return (void*)(&bmi_unit_conv.mass_balance_m);
-  else if (name.compare("soil_moisture_layers") == 0)
-    return (void*)this->state->lgar_bmi_params.soil_moisture_layers; // this is probably not needed
-  else if (name.compare("soil_thickness_layers") == 0)
-    return (void*)this->state->lgar_bmi_params.soil_moisture_layers;  // this too and, if needed, change soil_moisture_layers to soil_thickness_layers
+  else if (name.compare("soil_depth_layers") == 0)
+    return (void*)this->state->lgar_bmi_params.cum_layer_thickness_cm;  // this too and, if needed, change soil_moisture_layers to soil_thickness_layers
   else if (name.compare("soil_moisture_wetting_fronts") == 0)
     return (void*)this->state->lgar_bmi_params.soil_moisture_wetting_fronts;
   else if (name.compare("soil_depth_wetting_fronts") == 0)

--- a/src/bmi_main_lgar.cxx
+++ b/src/bmi_main_lgar.cxx
@@ -154,7 +154,7 @@ int main(int argc, char *argv[])
 
       // write layers data to file
       fprintf(outlayer_fptr,"# Timestep = %d, %s \n", i, time[i].c_str());
-      write_state(outlayer_fptr);
+      write_state(outlayer_fptr, model_state.get_model()->head);
     }
 
   }
@@ -261,7 +261,7 @@ ReadForcingData(std::string config_file, std::vector<std::string>& time, std::ve
 }
 
 
-extern void write_state(FILE *out){
+extern void write_state(FILE *out, struct wetting_front* head){
 
   struct wetting_front *current = head;
 

--- a/tests/configs/config_lasam_synth_0.txt
+++ b/tests/configs/config_lasam_synth_0.txt
@@ -1,4 +1,4 @@
-verbosity=none
+verbosity=low
 forcing_file=../forcing/forcing_data_synth_0.csv
 soil_params_file=../data/vG_default_params.dat
 layer_thickness=44.0,131.0,25.0[cm]

--- a/tests/main_unit_test_bmi.cxx
+++ b/tests/main_unit_test_bmi.cxx
@@ -45,27 +45,26 @@ int main(int argc, char *argv[])
   int num_wetting_fronts = 3;       // total number of wetting fronts
   bool test_status = true;          // unit test status flag, if test fail the flag turns false
   int num_input_vars = 3;           // total number of bmi input variables
-  int num_output_vars = 16;         // total number of bmi output variables
+  int num_output_vars = 15;         // total number of bmi output variables
 
   // *************************************************************************************
   // names of the bmi input/output variables and the corresponding sizes, with units of input variables
   std::vector <std::string> var_name_input = {"precipitation_rate", "potential_evapotranspiration_rate",
 					      "soil_temperature_profile"};
 
-  std::vector <std::string> var_name_output = {"soil_moisture_layers", "soil_moisture_wetting_fronts",
-					       "soil_thickness_layers", "soil_depth_wetting_fronts",
-					       "soil_num_wetting_fronts", "precipitation", "potential_evapotranspiration",
+  std::vector <std::string> var_name_output = {"soil_moisture_wetting_fronts", "soil_depth_layers",
+					       "soil_depth_wetting_fronts", "soil_num_wetting_fronts",
+					       "precipitation", "potential_evapotranspiration",
 					       "actual_evapotranspiration", "surface_runoff",
 					       "giuh_runoff", "soil_storage", "total_discharge",
 					       "infiltration", "percolation", "groundwater_to_stream_recharge",
 					       "mass_balance"};
 
   int nbytes_input[] = {sizeof(double), sizeof(double), sizeof(double)};
-  int nbytes_output[] = {int(num_layers * sizeof(double)), int(num_wetting_fronts * sizeof(double)),
-			 int(num_layers * sizeof(double)), int(num_wetting_fronts * sizeof(double)),
-			 sizeof(int),    sizeof(double), sizeof(double), sizeof(double), sizeof(double),
+  int nbytes_output[] = {int(num_wetting_fronts * sizeof(double)), int(num_layers * sizeof(double)),
+			 int(num_wetting_fronts * sizeof(double)), sizeof(int), sizeof(double),
 			 sizeof(double), sizeof(double), sizeof(double), sizeof(double), sizeof(double),
-			 sizeof(double), sizeof(double)};
+			 sizeof(double), sizeof(double), sizeof(double), sizeof(double), sizeof(double)};
 
   std::vector<std::string> bmi_units = {"mm h^-1", "mm h^-1", "K"};
   // *************************************************************************************


### PR DESCRIPTION
Refactored the code to run LGAR on multi-catchments, and fixed negative wetting front depth and mass balance issues. The code passes the unit tests, synthetic, and real field examples. The results are unchanged for the existing tests.

## Additions
- Most of the functions now take `head` as an argument
`
## Removals
- removed `head` as a global pointer

## Changes
- changes to functions' arguments

## Testing
1. MacOS (all tests passed)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Passes all existing automated tests
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
