### PR TITLE
fixed a bug where bottom_flux_cm_temp was not being added correctly t…

### DIFF
--- a/src/lgar.cxx
+++ b/src/lgar.cxx
@@ -1628,6 +1628,7 @@ extern double lgar_wetting_front_cross_domain_boundary(double domain_depth_cm, i
       next->psi_cm = calc_h_from_Se(Se_k, vg_a, vg_m, vg_n);
       next->K_cm_per_h = calc_K_from_Se(Se_k, Ksat_cm_per_h, vg_m);
       current = listDeleteFront(current->front_num, head);
+      bottom_flux_cm += bottom_flux_cm_temp; 
       break;
     }
     
@@ -1636,7 +1637,6 @@ extern double lgar_wetting_front_cross_domain_boundary(double domain_depth_cm, i
       listPrint(*head);
     }
     
-    bottom_flux_cm += bottom_flux_cm_temp;
     current = current->next;
     
     if (verbosity.compare("high") == 0){


### PR DESCRIPTION
…o bottom_flux_cm

[Short description explaining the high-level reason for the pull request]
LGAR has code that adds the bottom flux from a wetting front (bottom_flux_cm_temp) to the global bottom flux (bottom_flux_cm), but this line was not running in its old location. After moving the line, examples from the calibration workstream that previously crashed due to a mass balance error now run successfully. 

## Additions

-

## Removals

-

## Changes

-

## Testing
Prior to this update, example 01037380 from the Calibration workstream yielded:

State after merging wetting fronts...

[ (222.340206,0.39000000000000,1,1,0, 3.362181e+02, 0.072590 0.00000000000000)
(200.000000,0.38977950027040,1,2,1, 0.000000e+00, 0.057878 0.46385006117830) ] 
Domain boundary crossing (bottom flux calc.) 
Domain boundary crossing | ***** Wetting Front = 1 ****** 
 mass change/adjustment (dry_over_wet case) = 0.000000 
Moving/merging wetting fronts done... 
Calculating dz/dt .... 
Printing wetting fronts at this subtimestep... 

[ (200.000000,0.39000000000000,1,1,1, 0.000000e+00, 0.079200 0.00000000000000) ] 

Local mass balance at this timestep... 
      Error         =   0.0049260093 
      Initial water =  77.9988210124 
      Water added   =   0.0062909771 
      Ponded water  =   0.0000000000 
      Infiltration  =   0.0062909771 
      Runoff        =   0.0000000000 
      AET           =   0.0001859803 
      Percolation   =   0.0000000000 
      Final water   =  78.0000000000 
Local mass balance (in this timestep) is   0.0049260093, larger than expected, needs some debugging...
 zsh: abort      ngen/cmake_build/ngen  ""  "" 01037380_realization_config_bmi_calib.json 


Now, the same example successfully reaches its end time step. 

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
