### PR TITLE
calibratable_parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,10 +61,14 @@ IF((NOT ${NGEN}) AND (NOT ${STANDALONE}))
 ENDIF((NOT ${NGEN}) AND (NOT ${STANDALONE}))
 
 if(STANDALONE)
-  add_executable(${exe_name} ./src/bmi_main_lgar.cxx ./src/bmi_lgar.cxx ./src/lgar.cxx ./src/soil_funcs.cxx ./src/linked_list.cxx ./src/mem_funcs.cxx ./src/util_funcs.cxx ./src/aet.cxx ./giuh/giuh.h ./giuh/giuh.c)
+  add_executable(${exe_name} ./src/bmi_main_lgar.cxx ./src/bmi_lgar.cxx ./src/lgar.cxx ./src/soil_funcs.cxx
+  			     ./src/linked_list.cxx ./src/mem_funcs.cxx ./src/util_funcs.cxx ./src/aet.cxx
+			     ./giuh/giuh.h ./giuh/giuh.c)
   target_link_libraries(${exe_name} PRIVATE m)
 elseif(UNITTEST)
-  add_executable(${exe_name} ./tests/main_unit_test_bmi.cxx ./src/bmi_lgar.cxx ./src/lgar.cxx ./src/soil_funcs.cxx ./src/linked_list.cxx ./src/mem_funcs.cxx ./src/util_funcs.cxx ./src/aet.cxx ./giuh/giuh.h ./giuh/giuh.c)
+  add_executable(${exe_name} ./tests/main_unit_test_bmi.cxx ./src/bmi_lgar.cxx ./src/lgar.cxx ./src/soil_funcs.cxx
+  			     ./src/linked_list.cxx ./src/mem_funcs.cxx ./src/util_funcs.cxx ./src/aet.cxx ./giuh/giuh.h
+			     ./giuh/giuh.c)
   target_link_libraries(${exe_name} PRIVATE m)
 endif()
 
@@ -77,9 +81,11 @@ set(LASAM_LIB_DESC_CMAKE "OWP LASAM BMI Module Shared Library")
 add_compile_definitions(BMI_ACTIVE)
 
 if(WIN32)
-  add_library(lasambmi SHARED src/bmi_lgar.cxx src/lgar.cxx ./src/soil_funcs.cxx ./src/linked_list.cxx ./src/mem_funcs.cxx ./src/util_funcs.cxx ./src/aet.cxx ./giuh/giuh.c include/all.hxx ./giuh/giuh.h)
+  add_library(lasambmi SHARED src/bmi_lgar.cxx src/lgar.cxx ./src/soil_funcs.cxx ./src/linked_list.cxx ./src/mem_funcs.cxx
+  		       ./src/util_funcs.cxx ./src/aet.cxx ./giuh/giuh.c include/all.hxx ./giuh/giuh.h)
 else()
-   add_library(lasambmi SHARED src/bmi_lgar.cxx src/lgar.cxx ./src/soil_funcs.cxx ./src/linked_list.cxx ./src/mem_funcs.cxx ./src/util_funcs.cxx ./src/aet.cxx ./giuh/giuh.c include/all.hxx ./giuh/giuh.h)
+   add_library(lasambmi SHARED src/bmi_lgar.cxx src/lgar.cxx ./src/soil_funcs.cxx ./src/linked_list.cxx ./src/mem_funcs.cxx
+   			./src/util_funcs.cxx ./src/aet.cxx ./giuh/giuh.c include/all.hxx ./giuh/giuh.h)
 endif()
 
 target_include_directories(lasambmi PRIVATE include)

--- a/README.md
+++ b/README.md
@@ -72,3 +72,4 @@ Example configuration files for the two examples above are provided in the [conf
 | verbosity | string | high, low, none | - | debugging | - | controls IO (screen outputs and writing to disk) |
 | sft_coupled | Boolean | true, false | - | model coupling | impacts hydraulic conductivity | couples LASAM to SFT. Coupling to SFT reduces hydraulic conducitivity, and hence infiltration, when soil is frozen|
 | soil_z | double (1D array) | - | cm | spatial resolution | - | vertical resolution of the soil column (computational domain of the SFT model) |
+| calib_params | Boolean | true, false | - | calibratable params flag | impacts soil properties | If set to true, soil `smcmax`, `vg_m`, and `vg_alpha` are calibrated. defualt is false |

--- a/include/all.hxx
+++ b/include/all.hxx
@@ -143,6 +143,7 @@ struct lgar_bmi_parameters
   double *giuh_ordinates;       // geomorphological instantaneous unit hydrograph
   int    num_giuh_ordinates;    // number of giuh ordinates
 
+   int  calib_params_flag = 0;  // flag for calibratable parameters; if true, then calibratable params are updated otherwise not
 };
 
 // Define a data structure for local (timestep) and global mass balance parameters
@@ -177,14 +178,22 @@ struct lgar_mass_balance_variables
   double volrunoff_giuh_cm;   // volume of giuh runoff
   double volQ_cm;             // total outgoing water
   double volQ_gw_cm;          // outgoing water from ground reservoir to stream channel
+  double volchange_calib_cm;  // change in the amount of water due to calibratable parameters
   double local_mass_balance;  // local (per timestep) mass balance error
 };
 
+// Define a data structure for calibratable parameters
+// the structure holds pointer bmi output variables
+struct lgar_calib_parameters
+{
+  double *theta_e;     // theta_e = smcmax
+  double *vg_alpha;    // Van Genuchton alpha
+  double *vg_m;        // Van Genuchton m
+};
 
 // nested structure of structures; main structure for the use in bmi
 struct model_state
 {
-  //  struct wetting_front wetting_front;
   struct wetting_front*               head           = NULL; // head pointer to the current state
   struct wetting_front*               state_previous = NULL; // head pointer to the previous state,
                                                              // used in computing derivatives and mass balance
@@ -193,6 +202,7 @@ struct model_state
   struct lgar_mass_balance_variables  lgar_mass_balance;
   struct unit_conversion              units;
   struct lgar_bmi_input_parameters*   lgar_bmi_input_params;
+  struct lgar_calib_parameters        lgar_calib_params;
 };
 
 

--- a/include/all.hxx
+++ b/include/all.hxx
@@ -187,6 +187,7 @@ struct lgar_mass_balance_variables
 struct lgar_calib_parameters
 {
   double *theta_e;     // theta_e = smcmax
+  double *theta_r;     // theta_r = smcmin
   double *vg_alpha;    // Van Genuchton alpha
   double *vg_m;        // Van Genuchton m
   double *Ksat;        // Hydraulic conductivity [cm/hr]

--- a/include/all.hxx
+++ b/include/all.hxx
@@ -189,6 +189,7 @@ struct lgar_calib_parameters
   double *theta_e;     // theta_e = smcmax
   double *vg_alpha;    // Van Genuchton alpha
   double *vg_m;        // Van Genuchton m
+  double *Ksat;        // Hydraulic conductivity [cm/hr]
 };
 
 // nested structure of structures; main structure for the use in bmi

--- a/include/bmi_lgar.hxx
+++ b/include/bmi_lgar.hxx
@@ -66,9 +66,10 @@ public:
 
     // calibratable parameters
     this->calib_var_names[0] = "smcmax";
-    this->calib_var_names[1] = "van_genuchton_m";
-    this->calib_var_names[2] = "van_genuchton_alpha";
-    this->calib_var_names[3] = "hydraulic_conductivity";
+    this->calib_var_names[1] = "smcmin";
+    this->calib_var_names[2] = "van_genuchten_m";
+    this->calib_var_names[3] = "van_genuchten_alpha";
+    this->calib_var_names[4] = "hydraulic_conductivity";
   };
   
   void Initialize(std::string config_file);
@@ -131,7 +132,7 @@ private:
   struct model_state* state;
   static const int input_var_name_count  = 3;
   static const int output_var_name_count = 15;
-  static const int calib_var_name_count  = 4;
+  static const int calib_var_name_count  = 5;
   
   std::string input_var_names[input_var_name_count];
   std::string output_var_names[output_var_name_count];

--- a/include/bmi_lgar.hxx
+++ b/include/bmi_lgar.hxx
@@ -68,6 +68,7 @@ public:
     this->calib_var_names[0] = "smcmax";
     this->calib_var_names[1] = "van_genuchton_m";
     this->calib_var_names[2] = "van_genuchton_alpha";
+    this->calib_var_names[3] = "hydraulic_conductivity";
   };
   
   void Initialize(std::string config_file);
@@ -130,7 +131,7 @@ private:
   struct model_state* state;
   static const int input_var_name_count  = 3;
   static const int output_var_name_count = 15;
-  static const int calib_var_name_count  = 3;
+  static const int calib_var_name_count  = 4;
   
   std::string input_var_names[input_var_name_count];
   std::string output_var_names[output_var_name_count];

--- a/include/bmi_lgar.hxx
+++ b/include/bmi_lgar.hxx
@@ -63,6 +63,11 @@ public:
     this->output_var_names[20] = "cum_infiltration";
     this->output_var_names[21] = "cum_percolation";
     */
+
+    // calibratable parameters
+    this->calib_var_names[0] = "smcmax";
+    this->calib_var_names[1] = "van_genuchton_m";
+    this->calib_var_names[2] = "van_genuchton_alpha";
   };
   
   void Initialize(std::string config_file);
@@ -118,15 +123,19 @@ public:
   void GetGridFaceNodes(const int grid, int *face_nodes);
   void GetGridNodesPerFace(const int grid, int *nodes_per_face);
   void global_mass_balance();
+  double update_calibratable_parameters();
   struct model_state* get_model();
   
 private:
   struct model_state* state;
-  static const int input_var_name_count = 3;
+  static const int input_var_name_count  = 3;
   static const int output_var_name_count = 15;
+  static const int calib_var_name_count  = 3;
   
   std::string input_var_names[input_var_name_count];
   std::string output_var_names[output_var_name_count];
+  std::string calib_var_names[calib_var_name_count];
+  
   int num_giuh_ordinates;
   double *giuh_ordinates;
   double *giuh_runoff_queue;

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -57,7 +57,9 @@ void BmiLGAR::
 Update()
 {
   if (verbosity.compare("none") != 0) {
-    std::cerr<<"*** LASAM BMI Update... ***  \n";
+    std::cerr<<"---------------------------------------------------------\n";
+    std::cerr<<"|****************** LASAM BMI Update... ******************|\n";
+    std::cerr<<"---------------------------------------------------------\n";
   }
  
   // if lasam is coupled to soil freeze-thaw, frozen fraction module is called
@@ -70,8 +72,6 @@ Update()
     volchange_calib_cm = update_calibratable_parameters(); // change in soil water volume due to calibratable parameters
     state->lgar_bmi_params.calib_params_flag = false;
   }
-  
-  assert(state->lgar_bmi_params.calib_params_flag == false);
 
   double mm_to_cm = 0.1; // unit conversion
 
@@ -491,8 +491,10 @@ update_calibratable_parameters()
     assert (current != NULL);
 
     if (verbosity.compare("high") == 0 || verbosity.compare("low") == 0) {
-      std::cerr<<"Initial values    | soil_type = "<< soil <<", layer = "<<layer_num
+      std::cerr<<"----------- Calibratable parameters (initial values) ----------- \n";
+      std::cerr<<"| soil_type = "<< soil <<", layer = "<<layer_num
 	       <<", smcmax = "   << state->soil_properties[soil].theta_e
+	       <<", smcmin = "   << state->soil_properties[soil].theta_r
 	       <<", vg_m = "     << state->soil_properties[soil].vg_m
 	       <<", vg_alpha = " << state->soil_properties[soil].vg_alpha_per_cm
 	       <<", Ksat = "     << state->soil_properties[soil].Ksat_cm_per_h
@@ -500,6 +502,7 @@ update_calibratable_parameters()
     }
     
     state->soil_properties[soil].theta_e = state->lgar_calib_params.theta_e[layer_num-1];
+    state->soil_properties[soil].theta_r = state->lgar_calib_params.theta_r[layer_num-1];
     state->soil_properties[soil].vg_m    = state->lgar_calib_params.vg_m[layer_num-1];
     state->soil_properties[soil].vg_n    = 1.0/(1.0 - state->soil_properties[soil].vg_m);
     state->soil_properties[soil].vg_alpha_per_cm = state->lgar_calib_params.vg_alpha[layer_num-1];
@@ -510,8 +513,10 @@ update_calibratable_parameters()
 				       state->soil_properties[soil].theta_e, state->soil_properties[soil].theta_r);
 
     if (verbosity.compare("high") == 0 || verbosity.compare("low") == 0) {
-      std::cerr<<"Calibrated values | soil_type = "<< soil <<", layer = "<<layer_num
+      std::cerr<<"----------- Calibratable parameters (updated values) ----------- \n";
+      std::cerr<<"| soil_type = "<< soil <<", layer = "<<layer_num
 	       <<", smcmax = "   << state->soil_properties[soil].theta_e
+	       <<", smcmin = "   << state->soil_properties[soil].theta_r
 	       <<", vg_m = "     << state->soil_properties[soil].vg_m
 	       <<", vg_alpha = " << state->soil_properties[soil].vg_alpha_per_cm
 	       <<", Ksat = "     << state->soil_properties[soil].Ksat_cm_per_h
@@ -520,7 +525,7 @@ update_calibratable_parameters()
     
     current = current->next;
   }
-
+  
   if (verbosity.compare("high") == 0)
     listPrint(state->head);
   
@@ -558,8 +563,8 @@ GetVarGrid(std::string name)
     return 1;
   else if (name.compare("mass_balance") == 0)
     return 1;
-  else if (name.compare("soil_depth_layers") == 0  || name.compare("smcmax") == 0
-	   || name.compare("van_genuchton_m") == 0 || name.compare("van_genuchton_alpha") == 0
+  else if (name.compare("soil_depth_layers") == 0  || name.compare("smcmax") == 0 || name.compare("smcmin") == 0
+	   || name.compare("van_genuchten_m") == 0 || name.compare("van_genuchten_alpha") == 0
 	   || name.compare("hydraulic_conductivity") == 0) // array of doubles (fixed length)
     return 2;
   else if (name.compare("soil_moisture_wetting_fronts") == 0 || name.compare("soil_depth_wetting_fronts") == 0) // array of doubles (dynamic length)
@@ -774,9 +779,11 @@ GetValuePtr (std::string name)
     return (void*)this->state->lgar_bmi_params.soil_temperature;
   else if (name.compare("smcmax") == 0)
     return (void*)this->state->lgar_calib_params.theta_e;
-  else if (name.compare("van_genuchton_m") == 0)
+  else if (name.compare("smcmin") == 0)
+    return (void*)this->state->lgar_calib_params.theta_r;
+  else if (name.compare("van_genuchten_m") == 0)
     return (void*)this->state->lgar_calib_params.vg_m;
-  else if (name.compare("van_genuchton_alpha") == 0)
+  else if (name.compare("van_genuchten_alpha") == 0)
     return (void*)this->state->lgar_calib_params.vg_alpha;
   else if (name.compare("hydraulic_conductivity") == 0)
     return (void*)this->state->lgar_calib_params.Ksat;

--- a/src/bmi_main_lgar.cxx
+++ b/src/bmi_main_lgar.cxx
@@ -172,7 +172,7 @@ int main(int argc, char *argv[])
   elapsed = (double)(end_time - start_time) / CLOCKS_PER_SEC;
 
   std::cout<<setprecision(4);
-  std::cout<<"Time                     =   "<< elapsed <<" sec \n";
+  std::cout<<"Time                      =   "<< elapsed <<" sec \n";
 
   return SUCCESS;
 }

--- a/src/lgar.cxx
+++ b/src/lgar.cxx
@@ -85,6 +85,7 @@ extern void lgar_initialize(string config_file, struct model_state *state)
 
   // initialize array for holding calibratable parameters
   state->lgar_calib_params.theta_e  = new double[state->lgar_bmi_params.num_layers];
+  state->lgar_calib_params.theta_r  = new double[state->lgar_bmi_params.num_layers];
   state->lgar_calib_params.vg_m     = new double[state->lgar_bmi_params.num_layers];
   state->lgar_calib_params.vg_alpha = new double[state->lgar_bmi_params.num_layers];
   state->lgar_calib_params.Ksat     = new double[state->lgar_bmi_params.num_layers];
@@ -101,6 +102,7 @@ extern void lgar_initialize(string config_file, struct model_state *state)
     state->lgar_bmi_params.soil_depth_wetting_fronts[i]    = current->depth_cm * state->units.cm_to_m;
 
     state->lgar_calib_params.theta_e[i]  = state->soil_properties[soil].theta_e;
+    state->lgar_calib_params.theta_r[i]  = state->soil_properties[soil].theta_r;
     state->lgar_calib_params.vg_m[i]     = state->soil_properties[soil].vg_m;
     state->lgar_calib_params.vg_alpha[i] = state->soil_properties[soil].vg_alpha_per_cm;
     state->lgar_calib_params.Ksat[i]     = state->soil_properties[soil].Ksat_cm_per_h;

--- a/src/lgar.cxx
+++ b/src/lgar.cxx
@@ -72,22 +72,37 @@ using namespace std;
 // ############################################################################################
 extern void lgar_initialize(string config_file, struct model_state *state)
 {
-
+  int soil;
+  
   InitFromConfigFile(config_file, state);
   state->lgar_bmi_params.shape[0] = state->lgar_bmi_params.num_layers;
   state->lgar_bmi_params.shape[1] = state->lgar_bmi_params.num_wetting_fronts;
 
   // initial number of wetting fronts are same are number of layers
-  state->lgar_bmi_params.num_wetting_fronts = state->lgar_bmi_params.num_layers;
-  state->lgar_bmi_params.soil_depth_wetting_fronts = new double[state->lgar_bmi_params.num_wetting_fronts];
+  state->lgar_bmi_params.num_wetting_fronts           = state->lgar_bmi_params.num_layers;
+  state->lgar_bmi_params.soil_depth_wetting_fronts    = new double[state->lgar_bmi_params.num_wetting_fronts];
   state->lgar_bmi_params.soil_moisture_wetting_fronts = new double[state->lgar_bmi_params.num_wetting_fronts];
 
+  // initialize array for holding calibratable parameters
+  state->lgar_calib_params.theta_e  = new double[state->lgar_bmi_params.num_layers];
+  state->lgar_calib_params.vg_m     = new double[state->lgar_bmi_params.num_layers];
+  state->lgar_calib_params.vg_alpha = new double[state->lgar_bmi_params.num_layers];
+  
   // initialize thickness/depth and soil moisture of wetting fronts (used for model coupling)
+  // also initialize calibratable parameters
   struct wetting_front *current = state->head;
   for (int i=0; i<state->lgar_bmi_params.num_wetting_fronts; i++) {
     assert (current != NULL);
+    
+    soil = state->lgar_bmi_params.layer_soil_type[i+1];
+
     state->lgar_bmi_params.soil_moisture_wetting_fronts[i] = current->theta;
-    state->lgar_bmi_params.soil_depth_wetting_fronts[i] = current->depth_cm * state->units.cm_to_m;
+    state->lgar_bmi_params.soil_depth_wetting_fronts[i]    = current->depth_cm * state->units.cm_to_m;
+
+    state->lgar_calib_params.theta_e[i]  = state->soil_properties[soil].theta_e;
+    state->lgar_calib_params.vg_m[i]     = state->soil_properties[soil].vg_m;
+    state->lgar_calib_params.vg_alpha[i] = state->soil_properties[soil].vg_alpha_per_cm;
+    
     current = current->next;
   }
 
@@ -95,26 +110,25 @@ extern void lgar_initialize(string config_file, struct model_state *state)
   /* initialize bmi input variables to -1.0 (on purpose), this should be assigned (non-negative) and if not,
      the code will throw an error in the Update method */
   state->lgar_bmi_input_params->precipitation_mm_per_h = -1.0;
-  state->lgar_bmi_input_params->PET_mm_per_h = -1.0;
+  state->lgar_bmi_input_params->PET_mm_per_h           = -1.0;
 
   // initialize all global mass balance variables to zero
-  state->lgar_mass_balance.volprecip_cm = 0.0;
-  state->lgar_mass_balance.volin_cm = 0.0;
-  state->lgar_mass_balance.volend_cm = 0.0;
-  state->lgar_mass_balance.volAET_cm = 0.0;
-  state->lgar_mass_balance.volrech_cm = 0.0;
-  state->lgar_mass_balance.volrunoff_cm = 0.0;
-  state->lgar_mass_balance.volrunoff_giuh_cm = 0.0;
-  state->lgar_mass_balance.volQ_cm = 0.0;
-  state->lgar_mass_balance.volPET_cm = 0.0;
-  state->lgar_mass_balance.volon_cm = 0.0;
-
-  // setting volon and precip at the initial time to 0.0 as they determine the creation of surficail wetting front
-  state->lgar_mass_balance.volon_timestep_cm = 0.0;
+  state->lgar_mass_balance.volprecip_cm              = 0.0;
+  state->lgar_mass_balance.volin_cm                  = 0.0;
+  state->lgar_mass_balance.volend_cm                 = 0.0;
+  state->lgar_mass_balance.volAET_cm                 = 0.0;
+  state->lgar_mass_balance.volrech_cm                = 0.0;
+  state->lgar_mass_balance.volrunoff_cm              = 0.0;
+  state->lgar_mass_balance.volrunoff_giuh_cm         = 0.0;
+  state->lgar_mass_balance.volQ_cm                   = 0.0;
+  state->lgar_mass_balance.volPET_cm                 = 0.0;
+  state->lgar_mass_balance.volon_cm                  = 0.0;
+  state->lgar_mass_balance.volon_timestep_cm         = 0.0; /* setting volon and precip at the initial time to 0.0
+							       as they determine the creation of surficail wetting front */
   state->lgar_bmi_params.precip_previous_timestep_cm = 0.0;
-
-  // setting flux from groundwater_reservoir_to_stream to zero, will be non-zero when groundwater reservoir is added/simulated
-  state->lgar_mass_balance.volQ_gw_timestep_cm = 0.0;
+  state->lgar_mass_balance.volQ_gw_timestep_cm       = 0.0; /* setting flux from groundwater_reservoir_to_stream to zero,
+							       will be non-zero when groundwater reservoir is added/simulated */
+  state->lgar_mass_balance.volchange_calib_cm        = 0.0;
 }
 
 
@@ -455,7 +469,20 @@ extern void InitFromConfigFile(string config_file, struct model_state *state)
 
       continue;
     }
-
+    else if (param_key == "calib_params") {
+      if (param_value == "true") {
+	state->lgar_bmi_params.calib_params_flag = 1;
+      }
+      else if (param_value == "false") {
+	state->lgar_bmi_params.calib_params_flag = 0; // false
+      }
+      else {
+	std::cerr<<"Invalid option: calib_params must be true or false. \n";
+        abort();
+      }
+      
+      continue;
+    }
   }
 
   fp.close();
@@ -587,9 +614,9 @@ extern void InitFromConfigFile(string config_file, struct model_state *state)
     }
   }
   else {
-    state->lgar_bmi_params.soil_temperature = new double[1]();
+    state->lgar_bmi_params.soil_temperature   = new double[1]();
     state->lgar_bmi_params.soil_temperature_z = new double[1]();
-    state->lgar_bmi_params.num_cells_temp = 1;
+    state->lgar_bmi_params.num_cells_temp     = 1;
   }
 
   if (!is_ponded_depth_max_cm_set)
@@ -616,8 +643,8 @@ extern void InitFromConfigFile(string config_file, struct model_state *state)
   // initial mass in the system
   state->lgar_mass_balance.volstart_cm = lgar_calc_mass_bal(state->lgar_bmi_params.cum_layer_thickness_cm, state->head);
 
-  state->lgar_bmi_params.ponded_depth_cm = 0.0; // initially we start with a dry surface (no surface ponding)
-  state->lgar_bmi_params.nint = 120; // hacked, not needed to be an input option
+  state->lgar_bmi_params.ponded_depth_cm    = 0.0; // initially we start with a dry surface (no surface ponding)
+  state->lgar_bmi_params.nint               = 120; // hacked, not needed to be an input option
   state->lgar_bmi_params.num_wetting_fronts = state->lgar_bmi_params.num_layers;
 
   assert (state->lgar_bmi_params.num_layers == listLength(state->head));
@@ -627,8 +654,8 @@ extern void InitFromConfigFile(string config_file, struct model_state *state)
     std::cerr<<"No. of spatial intervals used in trapezoidal integration to compute G : "<<state->lgar_bmi_params.nint<<"\n";
   }
 
-  state->lgar_bmi_input_params = new lgar_bmi_input_parameters;
-  state->lgar_bmi_params.time_s = 0.0;
+  state->lgar_bmi_input_params     = new lgar_bmi_input_parameters;
+  state->lgar_bmi_params.time_s    = 0.0;
   state->lgar_bmi_params.timesteps = 0.0;
 
   if (verbosity.compare("none") != 0) {
@@ -648,7 +675,7 @@ extern void InitializeWettingFronts(int num_layers, double initial_psi_cm, int *
 				    double *frozen_factor, struct wetting_front** head, struct soil_properties_ *soil_properties)
 {
   int soil;
-  int front=0;
+  int front = 0;
   double Se, theta_init;
   bool bottom_flag;
   double Ksat_cm_per_h;
@@ -669,7 +696,7 @@ extern void InitializeWettingFronts(int num_layers, double initial_psi_cm, int *
     }
 
     // the next lines create the initial moisture profile
-    bottom_flag=true;  // all initial wetting fronts are in contact with the bottom of the layer they exist in
+    bottom_flag = true;  // all initial wetting fronts are in contact with the bottom of the layer they exist in
     // NOTE: The listInsertFront function does lots of stuff.
 
     current = listInsertFront(cum_layer_thickness_cm[layer],theta_init,front,layer,bottom_flag, head);
@@ -788,44 +815,45 @@ extern void lgar_update(struct model_state *state)
 // #########################################################################################
 extern void lgar_global_mass_balance(struct model_state *state, double *giuh_runoff_queue_cm)
 {
-  double volstart  = state->lgar_mass_balance.volstart_cm;
-  double volprecip = state->lgar_mass_balance.volprecip_cm;
-  double volrunoff = state->lgar_mass_balance.volrunoff_cm;
-  double volAET    = state->lgar_mass_balance.volAET_cm;
-  double volPET    = state->lgar_mass_balance.volPET_cm;
-  double volon     = state->lgar_mass_balance.volon_cm;
-  double volin     = state->lgar_mass_balance.volin_cm;
-  double volrech   = state->lgar_mass_balance.volrech_cm;
-  double volend    = state->lgar_mass_balance.volend_cm;
-  double volrunoff_giuh = state->lgar_mass_balance.volrunoff_giuh_cm;
-  double volend_giuh_cm = 0.0;
-  double total_Q_cm     = state->lgar_mass_balance.volQ_cm;
-
+  double volstart           = state->lgar_mass_balance.volstart_cm;
+  double volprecip          = state->lgar_mass_balance.volprecip_cm;
+  double volrunoff          = state->lgar_mass_balance.volrunoff_cm;
+  double volAET             = state->lgar_mass_balance.volAET_cm;
+  double volPET             = state->lgar_mass_balance.volPET_cm;
+  double volon              = state->lgar_mass_balance.volon_cm;
+  double volin              = state->lgar_mass_balance.volin_cm;
+  double volrech            = state->lgar_mass_balance.volrech_cm;
+  double volend             = state->lgar_mass_balance.volend_cm;
+  double volrunoff_giuh     = state->lgar_mass_balance.volrunoff_giuh_cm;
+  double volend_giuh_cm     = 0.0;
+  double total_Q_cm         = state->lgar_mass_balance.volQ_cm;
+  double volchange_calib_cm = state->lgar_mass_balance.volchange_calib_cm;
+  
   //check if the giuh queue have some water left at the end of simulaiton; needs to be included in the global mass balance
   // hold on; this is probably not needed as we have volrunoff in the balance; revist AJK
   for(int i=1; i <= state->lgar_bmi_params.num_giuh_ordinates; i++)
     volend_giuh_cm += giuh_runoff_queue_cm[i];
 
 
-  double global_error_cm = volstart + volprecip - volrunoff - volAET - volon - volrech - volend;
-
+  double global_error_cm = volstart + volprecip - volrunoff - volAET - volon - volrech - volend + volchange_calib_cm;
 
  printf("\n********************************************************* \n");
  printf("-------------------- Simulation Summary ----------------- \n");
  //printf("Time (sec)                 = %6.10f \n", elapsed);
  printf("------------------------ Mass balance ------------------- \n");
- printf("Initial water in soil    = %14.10f cm\n", volstart);
- printf("Total precipitation      = %14.10f cm\n", volprecip);
- printf("Total infiltration       = %14.10f cm\n", volin);
- printf("Final water in soil      = %14.10f cm\n", volend);
- printf("Surface ponded water     = %14.10f cm\n", volon);
- printf("Surface runoff           = %14.10f cm\n", volrunoff);
- printf("GIUH runoff              = %14.10f cm\n", volrunoff_giuh);
- printf("Total percolation        = %14.10f cm\n", volrech);
- printf("Total AET                = %14.10f cm\n", volAET);
- printf("Total PET                = %14.10f cm\n", volPET);
- printf("Total discharge (Q)      = %14.10f cm\n", total_Q_cm);
- printf("Global balance           =   %.6e cm\n", global_error_cm);
+ printf("Initial water in soil     = %14.10f cm\n", volstart);
+ printf("Total precipitation       = %14.10f cm\n", volprecip);
+ printf("Total infiltration        = %14.10f cm\n", volin);
+ printf("Final water in soil       = %14.10f cm\n", volend);
+ printf("Surface ponded water      = %14.10f cm\n", volon);
+ printf("Surface runoff            = %14.10f cm\n", volrunoff);
+ printf("GIUH runoff               = %14.10f cm\n", volrunoff_giuh);
+ printf("Total percolation         = %14.10f cm\n", volrech);
+ printf("Total AET                 = %14.10f cm\n", volAET);
+ printf("Total PET                 = %14.10f cm\n", volPET);
+ printf("Total discharge (Q)       = %14.10f cm\n", total_Q_cm);
+ printf("Vol change (calibration)  = %14.10f cm\n", volchange_calib_cm);
+ printf("Global balance            =   %.6e cm\n", global_error_cm);
 
 }
 

--- a/src/lgar.cxx
+++ b/src/lgar.cxx
@@ -87,6 +87,7 @@ extern void lgar_initialize(string config_file, struct model_state *state)
   state->lgar_calib_params.theta_e  = new double[state->lgar_bmi_params.num_layers];
   state->lgar_calib_params.vg_m     = new double[state->lgar_bmi_params.num_layers];
   state->lgar_calib_params.vg_alpha = new double[state->lgar_bmi_params.num_layers];
+  state->lgar_calib_params.Ksat     = new double[state->lgar_bmi_params.num_layers];
   
   // initialize thickness/depth and soil moisture of wetting fronts (used for model coupling)
   // also initialize calibratable parameters
@@ -102,6 +103,7 @@ extern void lgar_initialize(string config_file, struct model_state *state)
     state->lgar_calib_params.theta_e[i]  = state->soil_properties[soil].theta_e;
     state->lgar_calib_params.vg_m[i]     = state->soil_properties[soil].vg_m;
     state->lgar_calib_params.vg_alpha[i] = state->soil_properties[soil].vg_alpha_per_cm;
+    state->lgar_calib_params.Ksat[i]     = state->soil_properties[soil].Ksat_cm_per_h;
     
     current = current->next;
   }

--- a/tests/configs/unittest.txt
+++ b/tests/configs/unittest.txt
@@ -10,3 +10,4 @@ layer_soil_type=13,14,15
 max_soil_types=15
 wilting_point_psi=15495.0[cm]
 giuh_ordinates=0.06,0.51,0.28,0.12,0.03
+calib_params=true

--- a/tests/main_unit_test_bmi.cxx
+++ b/tests/main_unit_test_bmi.cxx
@@ -587,8 +587,8 @@ int main(int argc, char *argv[])
  
   // Get the initial values set through the config file
   model_calib.GetValue("smcmax", &smcmax[0]);
-  model_calib.GetValue("van_genuchton_m", &vg_m[0]);
-  model_calib.GetValue("van_genuchton_alpha", &vg_alpha[0]);
+  model_calib.GetValue("van_genuchten_m", &vg_m[0]);
+  model_calib.GetValue("van_genuchten_alpha", &vg_alpha[0]);
   model_calib.GetValue("hydraulic_conductivity", &Ksat[0]);
   
   for (int i=0; i < num_layers; i++)
@@ -598,14 +598,14 @@ int main(int argc, char *argv[])
 
   // set the new values
   model_calib.SetValue("smcmax", &smcmax_set[0]);
-  model_calib.SetValue("van_genuchton_m", &vg_m_set[0]);
-  model_calib.SetValue("van_genuchton_alpha", &vg_alpha_set[0]);
+  model_calib.SetValue("van_genuchten_m", &vg_m_set[0]);
+  model_calib.SetValue("van_genuchten_alpha", &vg_alpha_set[0]);
   model_calib.SetValue("hydraulic_conductivity", &Ksat_set[0]);
  
   // get the new/updated values
   model_calib.GetValue("smcmax", &smcmax[0]);
-  model_calib.GetValue("van_genuchton_m", &vg_m[0]);
-  model_calib.GetValue("van_genuchton_alpha", &vg_alpha[0]);
+  model_calib.GetValue("van_genuchten_m", &vg_m[0]);
+  model_calib.GetValue("van_genuchten_alpha", &vg_alpha[0]);
   model_calib.GetValue("hydraulic_conductivity", &Ksat[0]);
  
   

--- a/tests/main_unit_test_bmi.cxx
+++ b/tests/main_unit_test_bmi.cxx
@@ -26,7 +26,7 @@
 
 int main(int argc, char *argv[])
 {
-  BmiLGAR model;
+  BmiLGAR model, model_calib;
 
    if (argc != 2) {
     printf("Usage: ../build/lasam_unitest configs/unittest.txt \n");
@@ -38,14 +38,15 @@ int main(int argc, char *argv[])
   std::cout<<"\n**************** BEGIN LASAM BMI UNIT TEST *******************\n";
 
   model.Initialize(argv[1]);
-
+  model_calib.Initialize(argv[1]);
+  
   // The following variables and names are benchmark values and names, any (unintended/inconsistent) change to the bmi or model will lead to test failure.
   std::cout<<"\n**************** TEST VALUES ************************************\n";
-  int num_layers = 3;               // total number of layers
+  int num_layers         = 3;       // total number of layers
   int num_wetting_fronts = 3;       // total number of wetting fronts
-  bool test_status = true;          // unit test status flag, if test fail the flag turns false
-  int num_input_vars = 3;           // total number of bmi input variables
-  int num_output_vars = 15;         // total number of bmi output variables
+  bool test_status       = true;    // unit test status flag, if test fail the flag turns false
+  int num_input_vars     = 3;       // total number of bmi input variables
+  int num_output_vars    = 15;      // total number of bmi output variables
 
   // *************************************************************************************
   // names of the bmi input/output variables and the corresponding sizes, with units of input variables
@@ -384,7 +385,8 @@ int main(int argc, char *argv[])
   std::cout<<"| All tests passed until this point: "<<passed<<"\n";
   std::cout<<"| *************************************** \n";
   std::cout<<RESET<<"\n";
-
+  
+  assert (test_status == true);
 
   // Test BMI: GET VALUE FUNCTIONS
   std::cout<<"\n\n************** TEST BMI GETTER SETTER FUNCTIONS********************************\n";
@@ -529,7 +531,7 @@ int main(int argc, char *argv[])
   
   std::cout<<GREEN<<"\n";
   std::cout<<"| *************************************** \n";
-  std::cout<<"| All BMI Tests passed: "<<passed<<"\n";
+  std::cout<<"| All BMI Tests passed: "<< passed <<"\n";
   std::cout<<"| Infiltration [mm] : (benchmark vs computed) | "<< infiltration_check_mm <<" vs "
 	   << infiltration_computed * m_to_mm <<"\n";
   std::cout<<"| PET [mm]          : (benchmark vs computed) | "<< PET_check_mm <<" vs "<< PET_computed * m_to_mm <<"\n";
@@ -537,26 +539,100 @@ int main(int argc, char *argv[])
   std::cout<<"| *************************************** \n";
   std::cout<<RESET<<"\n";
 
+  assert (test_status == true);
+  
   // to print global mass balance
   //model.Finalize();
 
   if (fabs(infiltration_check_mm - infiltration_computed * m_to_mm) > 1.E-5) {
     std::stringstream errMsg;
-    errMsg << "Error between benchmark and simulated infiltration is "<< fabs(infiltration_check_mm - infiltration_computed * m_to_cm) << " which is unexpected. \n";
+    errMsg << "Error between benchmark and simulated infiltration is "<<
+      fabs(infiltration_check_mm - infiltration_computed * m_to_cm) << " which is unexpected. \n";
     throw std::runtime_error(errMsg.str());
   }
 
   if (fabs(PET_check_mm - PET_computed * m_to_mm) > 1.E-5) {
     std::stringstream errMsg;
-    errMsg << "Error between benchmark and simulated PET is "<< fabs(PET_check_mm - PET_computed * m_to_mm) << " which is unexpected. \n";
+    errMsg << "Error between benchmark and simulated PET is "<< fabs(PET_check_mm - PET_computed * m_to_mm)
+	   << " which is unexpected. \n";
     throw std::runtime_error(errMsg.str());
   }
 
   if (fabs(AET_check_mm - AET_computed * m_to_mm) > 1.E-5) {
     std::stringstream errMsg;
-    errMsg << "Error between benchmark and simulated AET is "<< fabs(AET_check_mm - AET_computed * m_to_mm) << " which is unexpected. \n";
+    errMsg << "Error between benchmark and simulated AET is "<< fabs(AET_check_mm - AET_computed * m_to_mm)
+	   << " which is unexpected. \n";
     throw std::runtime_error(errMsg.str());
   }
 
+
+  std::cout<<GREEN<<"\n";
+  std::cout<<"| *************************************** \n";
+  std::cout<<"| LASAM Calibration test "<< passed <<"\n";
+  
+  double rain_precip = 1.2; // mm/hr
+  double evapotran   = 3.0; // mm/hr
+  
+
+  // Testing Calibratable parameters
+  double *smcmax   = new double[num_layers];
+  double *vg_m     = new double[num_layers];
+  double *vg_alpha = new double[num_layers];
+
+  double smcmax_set[]   = {0.3513, 0.3773, 0.3617};
+  double vg_m_set[]     = {0.30681, 0.130177, 0.280843};
+  double vg_alpha_set[] = {0.0021297, 0.0073272, 0.0027454};
+
+  // Get the initial values set through the config file
+  model_calib.GetValue("smcmax", &smcmax[0]);
+  model_calib.GetValue("van_genuchton_m", &vg_m[0]);
+  model_calib.GetValue("van_genuchton_alpha", &vg_alpha[0]);
+
+  for (int i=0; i < num_layers; i++)
+    std::cout<<"| Initial values: layer = "<< i+1 <<", smcmax= "<<smcmax[i]<<", vg_m= "<<vg_m[i]<<", vg_alpha="<<vg_alpha[i]<<"\n";
+
+  // set the new values
+  model_calib.SetValue("smcmax", &smcmax_set[0]);
+  model_calib.SetValue("van_genuchton_m", &vg_m_set[0]);
+  model_calib.SetValue("van_genuchton_alpha", &vg_alpha_set[0]);
+
+  // get the new/updated values
+  model_calib.GetValue("smcmax", &smcmax[0]);
+  model_calib.GetValue("van_genuchton_m", &vg_m[0]);
+  model_calib.GetValue("van_genuchton_alpha", &vg_alpha[0]);
+
+  
+  for (int i=0; i < num_layers; i++) {
+    if (fabs(smcmax[i]  - smcmax_set[i]) > 1.E-5) {
+      std::stringstream errMsg;
+      errMsg << "Mismatch between smcmax calibrated values set and get "<< smcmax_set[i]<<" "<<smcmax[i]
+	     << " which is unexpected. \n";
+      throw std::runtime_error(errMsg.str());
+    }
+
+    if (fabs(vg_m[i]  - vg_m_set[i]) > 1.E-5) {
+      std::stringstream errMsg;
+      errMsg << "Mismatch between vg_m calibrated values set and get "<< vg_m_set[i]<<" "<<vg_m[i]
+	     << " which is unexpected. \n";
+      throw std::runtime_error(errMsg.str());
+    }
+
+  if (fabs(vg_alpha[i]  - vg_alpha_set[i]) > 1.E-5) {
+      std::stringstream errMsg;
+      errMsg << "Mismatch between vg_alpha calibrated values set and get "<< vg_alpha_set[i]<<" "<<vg_alpha[i]
+	     << " which is unexpected. \n";
+      throw std::runtime_error(errMsg.str());
+    }
+    
+  }
+
+  std::cout<<RESET<<"\n";
+  // set forcing data for the timestep
+  model_calib.SetValue("precipitation_rate", &rain_precip);
+  model_calib.SetValue("potential_evapotranspiration_rate", &evapotran);
+  model_calib.Update();
+  //model.SetValue("van_genuchton_m", &vg_m[0]);
+  //model.SetValue("van_genuchton_alpha", &vg_alpha[0]);
+  model_calib.Finalize();
   return FAILURE;
 }

--- a/tests/main_unit_test_bmi.cxx
+++ b/tests/main_unit_test_bmi.cxx
@@ -568,7 +568,7 @@ int main(int argc, char *argv[])
 
   std::cout<<GREEN<<"\n";
   std::cout<<"| *************************************** \n";
-  std::cout<<"| LASAM Calibration test "<< passed <<"\n";
+  std::cout<<"| LASAM Calibration test \n";
   
   double rain_precip = 1.2; // mm/hr
   double evapotran   = 3.0; // mm/hr
@@ -578,61 +578,82 @@ int main(int argc, char *argv[])
   double *smcmax   = new double[num_layers];
   double *vg_m     = new double[num_layers];
   double *vg_alpha = new double[num_layers];
+  double *Ksat     = new double[num_layers];
 
   double smcmax_set[]   = {0.3513, 0.3773, 0.3617};
   double vg_m_set[]     = {0.30681, 0.130177, 0.280843};
   double vg_alpha_set[] = {0.0021297, 0.0073272, 0.0027454};
-
+  double Ksat_set[]     = {0.446, 0.0743, 0.415};
+ 
   // Get the initial values set through the config file
   model_calib.GetValue("smcmax", &smcmax[0]);
   model_calib.GetValue("van_genuchton_m", &vg_m[0]);
   model_calib.GetValue("van_genuchton_alpha", &vg_alpha[0]);
-
+  model_calib.GetValue("hydraulic_conductivity", &Ksat[0]);
+  
   for (int i=0; i < num_layers; i++)
-    std::cout<<"| Initial values: layer = "<< i+1 <<", smcmax= "<<smcmax[i]<<", vg_m= "<<vg_m[i]<<", vg_alpha="<<vg_alpha[i]<<"\n";
+    std::cout<<"| Initial values: layer = "<< i+1 <<", smcmax = "<< smcmax[i]
+	     <<", vg_m = "<< vg_m[i] <<", vg_alpha = " << vg_alpha[i]
+	     <<", Ksat = "<< Ksat[i] <<"\n";
 
   // set the new values
   model_calib.SetValue("smcmax", &smcmax_set[0]);
   model_calib.SetValue("van_genuchton_m", &vg_m_set[0]);
   model_calib.SetValue("van_genuchton_alpha", &vg_alpha_set[0]);
-
+  model_calib.SetValue("hydraulic_conductivity", &Ksat_set[0]);
+ 
   // get the new/updated values
   model_calib.GetValue("smcmax", &smcmax[0]);
   model_calib.GetValue("van_genuchton_m", &vg_m[0]);
   model_calib.GetValue("van_genuchton_alpha", &vg_alpha[0]);
-
+  model_calib.GetValue("hydraulic_conductivity", &Ksat[0]);
+ 
   
   for (int i=0; i < num_layers; i++) {
+    
     if (fabs(smcmax[i]  - smcmax_set[i]) > 1.E-5) {
       std::stringstream errMsg;
-      errMsg << "Mismatch between smcmax calibrated values set and get "<< smcmax_set[i]<<" "<<smcmax[i]
+      errMsg << "Mismatch between smcmax calibrated values set and get "<< smcmax_set[i]<<" "<< smcmax[i]
 	     << " which is unexpected. \n";
       throw std::runtime_error(errMsg.str());
     }
-
+    
     if (fabs(vg_m[i]  - vg_m_set[i]) > 1.E-5) {
       std::stringstream errMsg;
-      errMsg << "Mismatch between vg_m calibrated values set and get "<< vg_m_set[i]<<" "<<vg_m[i]
+      errMsg << "Mismatch between vg_m calibrated values set and get "<< vg_m_set[i]<<" "<< vg_m[i]
 	     << " which is unexpected. \n";
       throw std::runtime_error(errMsg.str());
     }
-
-  if (fabs(vg_alpha[i]  - vg_alpha_set[i]) > 1.E-5) {
+    
+    if (fabs(vg_alpha[i]  - vg_alpha_set[i]) > 1.E-5) {
       std::stringstream errMsg;
-      errMsg << "Mismatch between vg_alpha calibrated values set and get "<< vg_alpha_set[i]<<" "<<vg_alpha[i]
+      errMsg << "Mismatch between vg_alpha calibrated values set and get "<< vg_alpha_set[i]<<" "<< vg_alpha[i]
+	     << " which is unexpected. \n";
+      throw std::runtime_error(errMsg.str());
+    }
+    
+    if (fabs(Ksat[i]  - Ksat_set[i]) > 1.E-5) {
+      std::stringstream errMsg;
+      errMsg << "Mismatch between hydraulic conductivity calibrated values set and get "<< Ksat_set[i]<<" "<< Ksat[i]
 	     << " which is unexpected. \n";
       throw std::runtime_error(errMsg.str());
     }
     
   }
 
+  std::cout<<"|  \n";
+  for (int i=0; i < num_layers; i++)
+    std::cout<<"| Calib. values: layer = "<< i+1 <<", smcmax = "<< smcmax[i]
+	     <<", vg_m = "<< vg_m[i] <<", vg_alpha = " << vg_alpha[i]
+	     <<", Ksat = "<< Ksat[i] <<"\n";
+  std::cout<<"| *************************************** \n";
+  std::cout<<"| LASAM Calibration test = YES \n";
   std::cout<<RESET<<"\n";
   // set forcing data for the timestep
   model_calib.SetValue("precipitation_rate", &rain_precip);
   model_calib.SetValue("potential_evapotranspiration_rate", &evapotran);
   model_calib.Update();
-  //model.SetValue("van_genuchton_m", &vg_m[0]);
-  //model.SetValue("van_genuchton_alpha", &vg_alpha[0]);
+  
   model_calib.Finalize();
   return FAILURE;
 }


### PR DESCRIPTION
The PR adds calibratable parameters `smcmax`, `van_genuchten_alpha`,  `van_genuchten_m`, and `hydraulic_conductivity` to bmi parameters list.

## Additions
- Added four calibrabtable parameters (all 1D arrays corresponding to each layer)

## Removals
- None

## Changes
- No changes to the core functionality

## Testing

1. Tested unittest, synthetic tests, and other existing tests (with real forcings)
2. Tested the desired/expected behavior of the calibrated parameters

## Todo
1. Add documentation (after revising the main ReadME.md repo file)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: