### PR TITLE
Ptl mbal testing

### DIFF
--- a/include/all.hxx
+++ b/include/all.hxx
@@ -288,9 +288,6 @@ extern void lgar_move_wetting_fronts(double timestep_h, double *ponded_depth_cm,
 				     double *cum_layer_thickness_cm, int *soil_type_by_layer, double *frozen_factor,
 				     struct wetting_front** head, struct wetting_front* state_previous, struct soil_properties_ *soil_properties);
 
-//this allows for detection of the type of correction necessary (merge, layer cross, or lower bdy cross)
-extern int lgar_correction_type(int num_layers, double* cum_layer_thickness_cm, struct wetting_front* head);
-
 // the subroutine merges the wetting fronts; called from lgar_move_wetting_fronts
 extern void lgar_merge_wetting_fronts(int *soil_type, double *frozen_factor, struct wetting_front** head,
 				      struct soil_properties_ *soil_properties);
@@ -319,7 +316,7 @@ extern int wetting_front_free_drainage(struct wetting_front* head);
 // computes updated theta (soil moisture content) after moving down a wetting front; called for each wetting front to ensure mass is conserved
 extern double lgar_theta_mass_balance(int layer_num, int soil_num, double psi_cm, double new_mass,
 				      double prior_mass, double *AET_demand_cm, double *delta_theta, double *layer_thickness_cm,
-				      int *soil_type, struct soil_properties_ *soil_properties, struct wetting_front** head);
+				      int *soil_type, struct soil_properties_ *soil_properties);
 
 /********************************************************************/
 // Bmi functions

--- a/include/all.hxx
+++ b/include/all.hxx
@@ -272,12 +272,12 @@ extern int lgar_read_vG_param_file(char const* vG_param_file_name, int num_soil_
                                     struct soil_properties_ *soil_properties);
 
 // creates a surficial front (new top most wetting front)
-extern void lgar_create_surficial_front(double *ponded_depth_cm, double *volin, double dry_depth,
+extern void lgar_create_surficial_front(int num_layers, double *ponded_depth_cm, double *volin, double dry_depth,
 					double theta1, int *soil_type, double *cum_layer_thickness_cm,
 					double *frozen_factor, struct wetting_front **head, struct soil_properties_ *soil_properties);
 
 // computes the infiltration capacity, fp, of the soil
-extern double lgar_insert_water(bool use_closed_form_G, int nint, double timestep_h, double *ponded_depth,
+extern double lgar_insert_water(bool use_closed_form_G, int nint, double timestep_h, double AET_demand_cm, double *ponded_depth,
 				double *volin_this_timestep, double precip_timestep_cm, int wf_free_drainge_demand,
 				int num_layers, double ponded_depth_max_cm, int *soil_type, double *cum_layer_thickness_cm,
 				double *frozen_factor, struct wetting_front* head, struct soil_properties_ *soil_properties);
@@ -287,6 +287,9 @@ extern void lgar_move_wetting_fronts(double timestep_h, double *ponded_depth_cm,
 				     double old_mass, int number_of_layers, double *actual_ET_demand,
 				     double *cum_layer_thickness_cm, int *soil_type_by_layer, double *frozen_factor,
 				     struct wetting_front** head, struct wetting_front* state_previous, struct soil_properties_ *soil_properties);
+
+//this allows for detection of the type of correction necessary (merge, layer cross, or lower bdy cross)
+extern int lgar_correction_type(int num_layers, double* cum_layer_thickness_cm, struct wetting_front* head);
 
 // the subroutine merges the wetting fronts; called from lgar_move_wetting_fronts
 extern void lgar_merge_wetting_fronts(int *soil_type, double *frozen_factor, struct wetting_front** head,
@@ -315,8 +318,8 @@ extern int wetting_front_free_drainage(struct wetting_front* head);
 
 // computes updated theta (soil moisture content) after moving down a wetting front; called for each wetting front to ensure mass is conserved
 extern double lgar_theta_mass_balance(int layer_num, int soil_num, double psi_cm, double new_mass,
-				      double prior_mass, double *delta_theta, double *layer_thickness_cm,
-				      int *soil_type, struct soil_properties_ *soil_properties);
+				      double prior_mass, double *AET_demand_cm, double *delta_theta, double *layer_thickness_cm,
+				      int *soil_type, struct soil_properties_ *soil_properties, struct wetting_front** head);
 
 /********************************************************************/
 // Bmi functions

--- a/src/aet.cxx
+++ b/src/aet.cxx
@@ -28,8 +28,6 @@ extern double calc_aet(double PET_timestep_cm, double time_step_h, double wiltin
   struct wetting_front *current;
   
   double theta_wp;
-
-  // double relative_moisture_at_which_PET_equals_AET = 0.75;
   
   double Se,theta_e,theta_r;
   double vg_a, vg_m, vg_n;
@@ -46,7 +44,6 @@ extern double calc_aet(double PET_timestep_cm, double time_step_h, double wiltin
   vg_n      = soil_properties[soil_num].vg_n;
 
   // compute theta field capacity
-  // double theta_fc = (theta_e - theta_r) * relative_moisture_at_which_PET_equals_AET + theta_r;
   double head_at_which_PET_equals_AET_cm = 340.9;//*10/33; //340.9 is 0.33 atm, expressed in water depth, which is a good field capacity for most soils.
   //Coarser soils like sand will have a field capacity of 0.1 atm or so.
   double theta_fc = calc_theta_from_h(head_at_which_PET_equals_AET_cm, vg_a,vg_m, vg_n, theta_e, theta_r);

--- a/src/aet.cxx
+++ b/src/aet.cxx
@@ -29,7 +29,7 @@ extern double calc_aet(double PET_timestep_cm, double time_step_h, double wiltin
   
   double theta_wp;
 
-  double relative_moisture_at_which_PET_equals_AET = 0.75;
+  // double relative_moisture_at_which_PET_equals_AET = 0.75;
   
   double Se,theta_e,theta_r;
   double vg_a, vg_m, vg_n;
@@ -46,9 +46,13 @@ extern double calc_aet(double PET_timestep_cm, double time_step_h, double wiltin
   vg_n      = soil_properties[soil_num].vg_n;
 
   // compute theta field capacity
-  double theta_fc = (theta_e - theta_r) * relative_moisture_at_which_PET_equals_AET + theta_r;
+  // double theta_fc = (theta_e - theta_r) * relative_moisture_at_which_PET_equals_AET + theta_r;
+  double head_at_which_PET_equals_AET_cm = 340.9;//*10/33; //340.9 is 0.33 atm, expressed in water depth, which is a good field capacity for most soils.
+  //Coarser soils like sand will have a field capacity of 0.1 atm or so.
+  double theta_fc = calc_theta_from_h(head_at_which_PET_equals_AET_cm, vg_a,vg_m, vg_n, theta_e, theta_r);
   
   double wp_head_theta = calc_theta_from_h(wilting_point_psi_cm, vg_a,vg_m, vg_n, theta_e, theta_r);
+  
   
   theta_wp = (theta_fc - wp_head_theta)*1/2 + wp_head_theta; // theta_50 in python
 

--- a/src/lgar.cxx
+++ b/src/lgar.cxx
@@ -2534,19 +2534,15 @@ extern double lgar_theta_mass_balance(int layer_num, int soil_num, double psi_cm
 
     delta_mass_prev = delta_mass;
 
-
-    //so the above code that avoids infinite loops by breaking in certain cases works, but a fringe case must be addressed. 
-    //When theta is close to theta_r, the loop "while (delta_mass > tolerance)" will attempt to increase psi until mass balance closure occurs, but if the 
-    //AET value would be large enough to make theta less than theta_r (or if dzdt was large enough to make the WF move such that the updated theta would be less than theta_r),
-    //the loop would never be able to achieve mass balance closure, and it will break when the one of above conditions is met.
-    //So, the next few lines beginning with "if (delta_mass > tolerance)" addresses the rare case where water would not be able to be extracted without theta becoming less than theta_r anyway
   }
 
+  //There is a rare case where mass balance closure would require that theta<theta_r. 
+  //However, the above loop can never increase psi to the point where theta<theta_r, because theta must always be between theta_r and theta_r, because of the van Genuchten model (calc_theta_from_h).
+  //If we get to the case where theta<theta_r would be necessary for mass balance closure, then the above loop will break before delta_mass <= tolerance.
+  //In this rare case, the remaining mass balance error is put into AET. 
   if (delta_mass > tolerance){
     *AET_demand_cm = *AET_demand_cm - fabs(delta_mass - tolerance);
   }
-
-  theta = fmax(soil_properties[soil_num].theta_r, fmin(soil_properties[soil_num].theta_e, theta));
   
   return theta;
 

--- a/src/lgar.cxx
+++ b/src/lgar.cxx
@@ -1112,7 +1112,7 @@ extern void lgar_move_wetting_fronts(double timestep_h, double *volin_cm, int wf
 						 delta_thetas, delta_thickness, soil_type, soil_properties);
       actual_ET_demand = *AET_demand_cm;
       
-      current->theta = fmin(theta_new, theta_e);
+      current->theta = fmax(theta_r, fmin(theta_new, theta_e));
 
       double Se = calc_Se_from_theta(current->theta,theta_e,theta_r);
       current->psi_cm = calc_h_from_Se(Se, vg_a, vg_m, vg_n);
@@ -1254,7 +1254,7 @@ extern void lgar_move_wetting_fronts(double timestep_h, double *volin_cm, int wf
 						   delta_thetas, delta_thickness, soil_type, soil_properties);
   actual_ET_demand = *AET_demand_cm;
 
-	current->theta = fmin(theta_new, theta_e);
+	current->theta = fmax(theta_r, fmin(theta_new, theta_e));
 
       }
 
@@ -2545,6 +2545,8 @@ extern double lgar_theta_mass_balance(int layer_num, int soil_num, double psi_cm
   if (delta_mass > tolerance){
     *AET_demand_cm = *AET_demand_cm - fabs(delta_mass - tolerance);
   }
+
+  theta = fmax(soil_properties[soil_num].theta_r, fmin(soil_properties[soil_num].theta_e, theta));
   
   return theta;
 

--- a/src/lgar.cxx
+++ b/src/lgar.cxx
@@ -1317,11 +1317,6 @@ extern void lgar_move_wetting_fronts(double timestep_h, double *volin_cm, int wf
       actual_ET_demand = *AET_demand_cm;
       break;
     }
-    ////might want to delete
-    // if (iter>1000 && iter_aug_flag==FALSE){
-    //   factor = factor*100;
-    //   iter_aug_flag = TRUE;
-    // }
 
 	  if (current_mass < mass_timestep) {
 	    depth_new += 0.01 * factor;
@@ -2535,7 +2530,6 @@ extern double lgar_theta_mass_balance(int layer_num, int soil_num, double psi_cm
     
     // -ve pressure will return NAN, so terminate the loop if previous psi is way small and current psi is zero
     // the wetting front is almost saturated
-    // if (psi_cm_loc <= 0 && psi_cm_loc_prev < 1E-50) break;
     if (psi_cm_loc <= 0 && psi_cm_loc_prev < 0) break;
 
     delta_mass_prev = delta_mass;

--- a/src/soil_funcs.cxx
+++ b/src/soil_funcs.cxx
@@ -26,15 +26,107 @@
 /* used for redistribution following the equation published by Ogden and Saghafian 1995.       */
 /* to compile: "gcc one_block.c -lm"                                                           */
 /*                                                                                             */
-/* author: Fred Ogden, June, 2021,                                                             */
+/* author: Fred Ogden, June, 2021, edited by Peter La Follette in 2023                         */
+//updated to calculate G using an adaptive integral method, rather than always using a fixed number of trapezoids.
+//This really helps when the limits of integration in terms of psi are quite far apart, and also helps to save runtime.
 /***********************************************************************************************/
+
+// extern double calc_Geff(bool use_closed_form_G, double theta1, double theta2, double theta_e, double theta_r,
+//                         double vg_alpha, double vg_n, double vg_m, double h_min, double Ksat, int nint,
+// 			double lambda, double bc_psib_cm)
+// {
+//   double Geff;       // this is the result to be returned.
+
+//   if (use_closed_form_G==false) {
+//     // local variables
+//     // note: units of h in cm.  units of K in cm/s
+//     double h_i,h_f,Se_i,Se_f;  // variables to store initial and final values
+//     double Se;
+//     double h2;         // the head at the right-hand side of the trapezoid being integrated [m]
+//     double dh;         // the delta h over which integration is performed [m]
+//     double Se1,Se2;    // the scaled moisture content on left- and right-hand side of trapezoid
+//     double K1,K2;      // the K(h) values on the left and right of the region dh integrated [m]
+
+
+//     Se_i = calc_Se_from_theta(theta1,theta_e,theta_r);    // scaled initial water content (0-1) [-]
+//     Se_f = calc_Se_from_theta(theta2,theta_e,theta_r);    // scaled final water content (0-1) [-]
+
+//     h_i = calc_h_from_Se(Se_i,vg_alpha,vg_m,vg_n);  // capillary head associated with Se_i [cm]
+//     h_f = calc_h_from_Se(Se_f,vg_alpha,vg_m,vg_n);  // capillary head associated with Se_f [cm]
+
+//     if(h_i < h_min) {/* if the lower limit of integration is less than h_min FIXME */
+//       //return h_min; // commenting out as this is not used in the Python version
+//     }
+
+//     if (verbosity.compare("high") == 0) {
+//       // debug statements to see if calc_Se_from_h function is working properly
+//       Se = calc_Se_from_h(h_i,vg_alpha,vg_m,vg_n);
+//       printf("Se_i = %8.6lf,  Se_inverse = %8.6lf\n", Se_i, Se);
+
+//       Se = calc_Se_from_h(h_f,vg_alpha,vg_m,vg_n);
+//       printf("Se_f = %8.6lf,  Se_inverse = %8.6lf\n", Se_f, Se);
+//     }
+    
+//     // nint = number of "dh" intervals to integrate over using trapezoidal rule
+//     dh = (h_f-h_i)/(double)nint;
+//     Geff = 0.0;
+    
+//     // integrate k(h) dh from h_i to h_f, using trapezoidal rule, with subscript
+//     // 1 denoting the left-hand side of the trapezoid, and 2 denoting the right-hand side
+
+//     Se1 = Se_i;  // could just use Se_i in next statement.  Done 4 completeness.
+//     K1  = calc_K_from_Se(Se1, Ksat, vg_m);
+//     h2  = h_i + dh;
+    
+//     for(int i=1; i<=nint; i++) {
+
+//       Se2 = calc_Se_from_h(h2, vg_alpha, vg_m, vg_n);
+//       K2  = calc_K_from_Se(Se2, Ksat, vg_m);
+//       Geff += (K1+K2)*dh/2.0;                  // trapezoidal rule
+//       // reset for next time through loop
+//       K1 = K2;
+//       h2 += dh;
+//     }
+    
+//     Geff = fabs(Geff/Ksat);       // by convention Geff is a positive quantity
+
+//     if (verbosity.compare("high") == 0){
+//       printf ("Capillary suction (G) = %8.6lf \n", Geff);
+//     }
+
+//     return Geff;
+
+//   }
+//   else {
+
+//     double Se_f = calc_Se_from_theta(theta1,theta_e,theta_r);    // the scaled moisture content of the wetting front
+//     double Se_i = calc_Se_from_theta(theta2,theta_e,theta_r);    // the scaled moisture content below the wetting front
+//     double H_c  = bc_psib_cm*((2+3*lambda) / (1+3*lambda));         // Green ampt capillary drive parameter, which can be used in the approximation of G with the Brooks-Corey model (See Ogden and Saghafian, 1997)
+
+//     Geff = H_c*(pow(Se_i,(3+1/lambda))-pow(Se_f,(3+1/lambda)))/(1-pow(Se_f,(3+1/lambda)));
+    
+//     if (isinf(Geff)) {
+//       Geff = H_c;
+//     }
+//     if (isnan(Geff)) {
+//       Geff = H_c;
+//     }
+    
+//     return Geff;
+    
+//   }
+  
+// }
+
+
+
 extern double calc_Geff(bool use_closed_form_G, double theta1, double theta2, double theta_e, double theta_r,
-                        double vg_alpha, double vg_n, double vg_m, double h_min, double Ksat, int nint,
-			double lambda, double bc_psib_cm)
+                        double vg_alpha, double vg_n, double vg_m, double h_min, double Ksat, int nint, double lambda, double bc_psib_cm)
+
 {
   double Geff;       // this is the result to be returned.
 
-  if (use_closed_form_G==false) {
+  if (use_closed_form_G==false){
     // local variables
     // note: units of h in cm.  units of K in cm/s
     double h_i,h_f,Se_i,Se_f;  // variables to store initial and final values
@@ -43,7 +135,6 @@ extern double calc_Geff(bool use_closed_form_G, double theta1, double theta2, do
     double dh;         // the delta h over which integration is performed [m]
     double Se1,Se2;    // the scaled moisture content on left- and right-hand side of trapezoid
     double K1,K2;      // the K(h) values on the left and right of the region dh integrated [m]
-
 
     Se_i = calc_Se_from_theta(theta1,theta_e,theta_r);    // scaled initial water content (0-1) [-]
     Se_f = calc_Se_from_theta(theta2,theta_e,theta_r);    // scaled final water content (0-1) [-]
@@ -63,28 +154,54 @@ extern double calc_Geff(bool use_closed_form_G, double theta1, double theta2, do
       Se = calc_Se_from_h(h_f,vg_alpha,vg_m,vg_n);
       printf("Se_f = %8.6lf,  Se_inverse = %8.6lf\n", Se_f, Se);
     }
-    
+
     // nint = number of "dh" intervals to integrate over using trapezoidal rule
-    dh = (h_f-h_i)/(double)nint;
+    dh = -1*(h_f-h_i)/(double)nint;
+    dh = dh*0.01;
+
     Geff = 0.0;
-    
+
     // integrate k(h) dh from h_i to h_f, using trapezoidal rule, with subscript
     // 1 denoting the left-hand side of the trapezoid, and 2 denoting the right-hand side
 
     Se1 = Se_i;  // could just use Se_i in next statement.  Done 4 completeness.
     K1  = calc_K_from_Se(Se1, Ksat, vg_m);
-    h2  = h_i + dh;
-    
-    for(int i=1; i<=nint; i++) {
+    h2  = h_f + dh;
+
+    while(h2<h_i) {
+
+      double prior_h2 = h2;
 
       Se2 = calc_Se_from_h(h2, vg_alpha, vg_m, vg_n);
       K2  = calc_K_from_Se(Se2, Ksat, vg_m);
-      Geff += (K1+K2)*dh/2.0;                  // trapezoidal rule
+
+      if ( (K1-K2)/K2 > 0.02 ){//if K1 disagrees with K2 by more than this fraction, then dh is made smaller
+        dh = dh*0.5;
+      }
+      else if ( (K1-K2)/K2 < 0.03 ){//but if K1 and K2 are within a certain fraction of each other, then dh is made larger
+        dh = dh*10.0;
+      }
+      else{
+        dh = dh*2.0; //but if K1 and K2 are within a certain fraction of each other, then dh is made larger
+      }
+
+      if (h2<h_i){
+        Geff += (K1+K2)*dh/2.0;                  // trapezoidal rule
+      }
+      else{
+        dh = h_i - prior_h2;
+        Se2 = calc_Se_from_h(h_i, vg_alpha, vg_m, vg_n);
+        K2  = calc_K_from_Se(Se2, Ksat, vg_m);
+        Geff += (K1+K2)*dh/2.0;  
+      }
+
       // reset for next time through loop
       K1 = K2;
       h2 += dh;
+
     }
-    
+
+    //std::cerr<<"Integral = "<< Geff<<" "<<Ksat<<"\n";
     Geff = fabs(Geff/Ksat);       // by convention Geff is a positive quantity
 
     if (verbosity.compare("high") == 0){
@@ -93,27 +210,31 @@ extern double calc_Geff(bool use_closed_form_G, double theta1, double theta2, do
 
     return Geff;
 
-  }
-  else {
+    //if(Geff < h_min) Geff = h_min; AJ // as per Morel-Seytoux and Khanji
 
-    double Se_f = calc_Se_from_theta(theta1,theta_e,theta_r);    // the scaled moisture content of the wetting front
-    double Se_i = calc_Se_from_theta(theta2,theta_e,theta_r);    // the scaled moisture content below the wetting front
-    double H_c  = bc_psib_cm*((2+3*lambda) / (1+3*lambda));         // Green ampt capillary drive parameter, which can be used in the approximation of G with the Brooks-Corey model (See Ogden and Saghafian, 1997)
+    //return Geff;
 
-    Geff = H_c*(pow(Se_i,(3+1/lambda))-pow(Se_f,(3+1/lambda)))/(1-pow(Se_f,(3+1/lambda)));
-    
-    if (isinf(Geff)) {
-      Geff = H_c;
-    }
-    if (isnan(Geff)) {
-      Geff = H_c;
-    }
-    
-    return Geff;
-    
   }
-  
+   else {
+
+     double Se_f = calc_Se_from_theta(theta1,theta_e,theta_r);    // the scaled moisture content of the wetting front
+     double Se_i = calc_Se_from_theta(theta2,theta_e,theta_r);    // the scaled moisture content below the wetting front
+     double H_c = bc_psib_cm*((2+3*lambda)/(1+3*lambda));            // Green ampt capillary drive parameter, which can be used in the approximation of G with the Brooks-Corey model (See Ogden and Saghafian, 1997)
+     Geff = H_c*(pow(Se_i,(3+1/lambda))-pow(Se_f,(3+1/lambda)))/(1-pow(Se_f,(3+1/lambda)));
+     if (isinf(Geff)){
+       Geff = H_c;
+     }
+     if (isnan(Geff)){
+       Geff = H_c;
+     }
+
+     return Geff;
+
+  }
+
 }
+
+
 
 /**************************************/
 /* function to calculate theta from h */

--- a/src/soil_funcs.cxx
+++ b/src/soil_funcs.cxx
@@ -26,99 +26,10 @@
 /* used for redistribution following the equation published by Ogden and Saghafian 1995.       */
 /* to compile: "gcc one_block.c -lm"                                                           */
 /*                                                                                             */
-/* author: Fred Ogden, June, 2021, edited by Peter La Follette in 2023                         */
+/* author: Fred Ogden, June, 2021, edited by Peter La Follette in 2023 for adaptive integral   */
 //updated to calculate G using an adaptive integral method, rather than always using a fixed number of trapezoids.
 //This really helps when the limits of integration in terms of psi are quite far apart, and also helps to save runtime.
 /***********************************************************************************************/
-
-// extern double calc_Geff(bool use_closed_form_G, double theta1, double theta2, double theta_e, double theta_r,
-//                         double vg_alpha, double vg_n, double vg_m, double h_min, double Ksat, int nint,
-// 			double lambda, double bc_psib_cm)
-// {
-//   double Geff;       // this is the result to be returned.
-
-//   if (use_closed_form_G==false) {
-//     // local variables
-//     // note: units of h in cm.  units of K in cm/s
-//     double h_i,h_f,Se_i,Se_f;  // variables to store initial and final values
-//     double Se;
-//     double h2;         // the head at the right-hand side of the trapezoid being integrated [m]
-//     double dh;         // the delta h over which integration is performed [m]
-//     double Se1,Se2;    // the scaled moisture content on left- and right-hand side of trapezoid
-//     double K1,K2;      // the K(h) values on the left and right of the region dh integrated [m]
-
-
-//     Se_i = calc_Se_from_theta(theta1,theta_e,theta_r);    // scaled initial water content (0-1) [-]
-//     Se_f = calc_Se_from_theta(theta2,theta_e,theta_r);    // scaled final water content (0-1) [-]
-
-//     h_i = calc_h_from_Se(Se_i,vg_alpha,vg_m,vg_n);  // capillary head associated with Se_i [cm]
-//     h_f = calc_h_from_Se(Se_f,vg_alpha,vg_m,vg_n);  // capillary head associated with Se_f [cm]
-
-//     if(h_i < h_min) {/* if the lower limit of integration is less than h_min FIXME */
-//       //return h_min; // commenting out as this is not used in the Python version
-//     }
-
-//     if (verbosity.compare("high") == 0) {
-//       // debug statements to see if calc_Se_from_h function is working properly
-//       Se = calc_Se_from_h(h_i,vg_alpha,vg_m,vg_n);
-//       printf("Se_i = %8.6lf,  Se_inverse = %8.6lf\n", Se_i, Se);
-
-//       Se = calc_Se_from_h(h_f,vg_alpha,vg_m,vg_n);
-//       printf("Se_f = %8.6lf,  Se_inverse = %8.6lf\n", Se_f, Se);
-//     }
-    
-//     // nint = number of "dh" intervals to integrate over using trapezoidal rule
-//     dh = (h_f-h_i)/(double)nint;
-//     Geff = 0.0;
-    
-//     // integrate k(h) dh from h_i to h_f, using trapezoidal rule, with subscript
-//     // 1 denoting the left-hand side of the trapezoid, and 2 denoting the right-hand side
-
-//     Se1 = Se_i;  // could just use Se_i in next statement.  Done 4 completeness.
-//     K1  = calc_K_from_Se(Se1, Ksat, vg_m);
-//     h2  = h_i + dh;
-    
-//     for(int i=1; i<=nint; i++) {
-
-//       Se2 = calc_Se_from_h(h2, vg_alpha, vg_m, vg_n);
-//       K2  = calc_K_from_Se(Se2, Ksat, vg_m);
-//       Geff += (K1+K2)*dh/2.0;                  // trapezoidal rule
-//       // reset for next time through loop
-//       K1 = K2;
-//       h2 += dh;
-//     }
-    
-//     Geff = fabs(Geff/Ksat);       // by convention Geff is a positive quantity
-
-//     if (verbosity.compare("high") == 0){
-//       printf ("Capillary suction (G) = %8.6lf \n", Geff);
-//     }
-
-//     return Geff;
-
-//   }
-//   else {
-
-//     double Se_f = calc_Se_from_theta(theta1,theta_e,theta_r);    // the scaled moisture content of the wetting front
-//     double Se_i = calc_Se_from_theta(theta2,theta_e,theta_r);    // the scaled moisture content below the wetting front
-//     double H_c  = bc_psib_cm*((2+3*lambda) / (1+3*lambda));         // Green ampt capillary drive parameter, which can be used in the approximation of G with the Brooks-Corey model (See Ogden and Saghafian, 1997)
-
-//     Geff = H_c*(pow(Se_i,(3+1/lambda))-pow(Se_f,(3+1/lambda)))/(1-pow(Se_f,(3+1/lambda)));
-    
-//     if (isinf(Geff)) {
-//       Geff = H_c;
-//     }
-//     if (isnan(Geff)) {
-//       Geff = H_c;
-//     }
-    
-//     return Geff;
-    
-//   }
-  
-// }
-
-
 
 extern double calc_Geff(bool use_closed_form_G, double theta1, double theta2, double theta_e, double theta_r,
                         double vg_alpha, double vg_n, double vg_m, double h_min, double Ksat, int nint, double lambda, double bc_psib_cm)

--- a/tests/main_unit_test_bmi.cxx
+++ b/tests/main_unit_test_bmi.cxx
@@ -453,8 +453,8 @@ int main(int argc, char *argv[])
 
   // Benchmark values of wetting fronts depth and moisture (b is for benchmark)
   //std::vector<double> depth_wf_b = {1.873813, 44.00,175.0, 200.0}; // in cm
-  std::vector<double> depth_wf_b = {4.3762450616157, 44.00,175.0, 200.0}; // in cm
-  std::vector<double> theta_wf_b = {0.2153965837523, 0.172703948143618, 0.252113867764474, 0.179593529195751};
+  std::vector<double> depth_wf_b = {4.55355, 44.00,175.0, 200.0}; // in cm
+  std::vector<double> theta_wf_b = {0.213716, 0.172703948143618, 0.252113867764474, 0.179593529195751};
 
   int m_to_cm = 100;
   int m_to_mm = 1000;
@@ -518,7 +518,7 @@ int main(int argc, char *argv[])
 
   // check total infiltration, AET, and PET.
   double infiltration_check_mm = 1.896;  // in mm
-  double AET_check_mm          = 0.0288829525; // in mm
+  double AET_check_mm          = 0.029801; // in mm
   double PET_check_mm          = 0.104; // in mm
   double infiltration_computed = 0.0;
   double PET_computed          = 0.0;
@@ -562,6 +562,9 @@ int main(int argc, char *argv[])
     std::stringstream errMsg;
     errMsg << "Error between benchmark and simulated AET is "<< fabs(AET_check_mm - AET_computed * m_to_mm)
 	   << " which is unexpected. \n";
+     printf("benchmark AET: %lf \n", AET_check_mm);
+     printf("computed AET: %lf \n", AET_computed*m_to_mm);
+
     throw std::runtime_error(errMsg.str());
   }
 


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Additions
After the calibration workstream experienced some errors with LASAM, we decided it was a good idea to run LASAM with a large number of parameter sets and debug all errors that arose. In this branch, I've tested LASAM with 42k randomly generated parameter sets, including humid and arid forcing data, in the framework and in standalone mode, and in one and 3 layer scenarios. Currently the model runs successfully with each parameter set. 

Debugging mostly had to do with implementing many small changes to address unlikely scenarios that we did not anticipate earlier in the model's development. While the bulk of the code changes address such errors (brief comments are given describing why the code was added in most cases), this push also has the implementation of an adaptive integral to calculate the capillary drive G, as well as a redefinition of field capacity as a head rather than as a fixed relative water content. Both of these changes were developed as part of LGARTO model development. 
-

## Removals
Removals focus on lines of code that yielded errors in some tested cases. 
-

## Changes

-

## Testing

Testing was achieved by running the model with 42k unique parameter sets. 

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
