### PR TITLE
updating LASAM to take field capacity as a parameter in the config file

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -16,10 +16,11 @@ A detailed description of the parameters for model configuration (i.e., initiali
 | endtime | double (scalar)| >0 | sec, min, hr, d | simulation duration | - | time at which model simulation ends |
 | layer_soil_type | int (1D array) | - | - | state variable | - | layer soil type (read from the database file soil_params_file) |
 | max_soil_types | int | >1 | - | - | - | maximum number of soil types read from the file soil_params_file (default is set to 15) |
-| wilting_point_psi | double (scalar) | - | cm | state variable | - | wilting point (the amount of water not available for plants) used in computing AET |
+| wilting_point_psi | double (scalar) | - | cm | state variable | - | wilting point (the amount of water not available for plants) used in computing AET. Suggested value is 15495.0 cm, corresponding to 15 atm. |
+| field_capacity_psi | double (scalar) | - | cm | state variable | - | capillary head corresponding to volumetric water content at which gravity drainage becomes slower, used in computing AET. Suggested value is 340.9 cm for most soils, corresponding to 1/3 atm, and 103.3 cm for sands, corresponding to 1/10 atm. |
 | use_closed_form_G | bool | true or false | - | - | - | determines whether the numeric integral or closed form for G is used; a value of true will use the closed form. This defaults to false. |
 | giuh_ordinates | double (1D array)| - | - | state parameter | - | GIUH ordinates (for giuh based surface runoff) |
 | verbosity | string | high, low, none | - | debugging | - | controls IO (screen outputs and writing to disk) |
 | sft_coupled | Boolean | true, false | - | model coupling | impacts hydraulic conductivity | couples LASAM to SFT. Coupling to SFT reduces hydraulic conducitivity, and hence infiltration, when soil is frozen|
 | soil_z | double (1D array) | - | cm | spatial resolution | - | vertical resolution of the soil column (computational domain of the SFT model) |
-| calib_params | Boolean | true, false | - | calibratable params flag | impacts soil properties | If set to true, soil `smcmax`, `smcmin`, `vg_m`, and `vg_alpha` are calibrated. defualt is false. vg = van Genuchten, SMC= soil moisture content |
+| calib_params | Boolean | true, false | - | calibratable params flag | impacts soil properties | If set to true, soil `smcmax`, `smcmin`, `vg_n`, `vg_alpha`, `hydraulic_conductivity`, `field_capacity_psi`, and `ponded_depth_max` are calibrated. defualt is false. vg = van Genuchten, SMC= soil moisture content |

--- a/configs/config_lasam_Bushland.txt
+++ b/configs/config_lasam_Bushland.txt
@@ -11,4 +11,5 @@ use_closed_form_G=false
 layer_soil_type=16,17,18
 max_soil_types=25
 wilting_point_psi=15495.0[cm]
+field_capacity_psi=340.9[cm]
 giuh_ordinates=0.06,0.51,0.28,0.12,0.03

--- a/configs/config_lasam_Phillipsburg.txt
+++ b/configs/config_lasam_Phillipsburg.txt
@@ -11,4 +11,5 @@ use_closed_form_G=false
 layer_soil_type=13,14,15
 max_soil_types=25
 wilting_point_psi=15495.0[cm]
+field_capacity_psi=340.9[cm]
 giuh_ordinates=0.06,0.51,0.28,0.12,0.03

--- a/configs/config_lasam_sft_ngen.txt
+++ b/configs/config_lasam_sft_ngen.txt
@@ -11,6 +11,7 @@ use_closed_form_G=false
 layer_soil_type=13,14,15
 max_soil_types=25
 wilting_point_psi=15495.0[cm]
+field_capacity_psi=340.9[cm]
 giuh_ordinates=0.06,0.51,0.28,0.12,0.03
 sft_coupled=true
 soil_z=10,20,30,40,50,60,70,80,90,100.0,110.,120,130.,140.,150.,160.,170.,180.,190.,200.0[cm]

--- a/include/all.hxx
+++ b/include/all.hxx
@@ -192,8 +192,8 @@ struct lgar_calib_parameters
   double *vg_n;                  // Van Genuchten n [-]
   double *vg_alpha;              // Van Genuchten alpha [1/cm]
   double *Ksat;                  // Hydraulic conductivity [cm/hr]
-  double field_capacity_psi;    // field capacity in capillary head [cm]
-  double ponded_depth_max;      // maximum ponded depth of surface water [cm]
+  double *field_capacity_psi;    // field capacity in capillary head [cm]
+  double *ponded_depth_max;      // maximum ponded depth of surface water [cm]
 
 };
 

--- a/include/all.hxx
+++ b/include/all.hxx
@@ -192,8 +192,8 @@ struct lgar_calib_parameters
   double *vg_n;                  // Van Genuchten n [-]
   double *vg_alpha;              // Van Genuchten alpha [1/cm]
   double *Ksat;                  // Hydraulic conductivity [cm/hr]
-  double *field_capacity_psi;    // field capacity in capillary head [cm]
-  double *ponded_depth_max;      // maximum ponded depth of surface water [cm]
+  double field_capacity_psi;    // field capacity in capillary head [cm]
+  double ponded_depth_max;      // maximum ponded depth of surface water [cm]
 
 };
 

--- a/include/all.hxx
+++ b/include/all.hxx
@@ -3,7 +3,7 @@
 #define _ALL_HXX
 
 /*
-  authors : Ahmad Jan and Fred Ogden
+  authors : Ahmad Jan and Fred Ogden and Peter La Follette
   year    : 2022
   email   : ahmad.jan@noaa.gov
   - This header file constains functions' definitions used in the lgar.cxx, bmi_lasam.cxx and in other files.
@@ -128,6 +128,7 @@ struct lgar_bmi_parameters
 					    depth from the surface in meters */
   double *frozen_factor;                 // frozen factor added to the hydraulic conductivity due to coupling to soil freeze-thaw
   double  wilting_point_psi_cm;          // wilting point (the amount of water not available for plants or not accessible by plants)
+  double  field_capacity_psi_cm;          // field capacity represented as a capillary head. Note that both wilting point and field capacity are specified for the whole model domain with single values
   bool   use_closed_form_G = false;      /* true if closed form of capillary drive calculation is desired, false if numeric integral
 					    for capillary drive calculation is desired */
   double ponded_depth_cm;                // amount of water on the surface unavailable for surface runoff
@@ -188,8 +189,8 @@ struct lgar_calib_parameters
 {
   double *theta_e;     // theta_e = smcmax
   double *theta_r;     // theta_r = smcmin
-  double *vg_alpha;    // Van Genuchton alpha
-  double *vg_m;        // Van Genuchton m
+  double *vg_alpha;    // Van Genuchten alpha
+  double *vg_m;        // Van Genuchten m
   double *Ksat;        // Hydraulic conductivity [cm/hr]
 };
 
@@ -332,7 +333,7 @@ extern void InitializeWettingFronts(int num_layers, double initial_psi_cm, int *
 /*Other function prototypes for doing hydrology calculations, etc.  */
 /********************************************************************/
 
-extern double calc_aet(double PET_timestep_cm, double timestep_h, double wilting_point_psi_cm, int *soil_type,
+extern double calc_aet(double PET_timestep_cm, double timestep_h, double wilting_point_psi_cm, double field_capacity_psi_cm, int *soil_type,
 		       double AET_thresh_Theta, double AET_expon, struct wetting_front* head, struct soil_properties_ *soil_props);
 
 /********************************************************************/

--- a/include/all.hxx
+++ b/include/all.hxx
@@ -187,11 +187,14 @@ struct lgar_mass_balance_variables
 // the structure holds pointer bmi output variables
 struct lgar_calib_parameters
 {
-  double *theta_e;     // theta_e = smcmax
-  double *theta_r;     // theta_r = smcmin
-  double *vg_alpha;    // Van Genuchten alpha
-  double *vg_m;        // Van Genuchten m
-  double *Ksat;        // Hydraulic conductivity [cm/hr]
+  double *theta_e;               // theta_e = smcmax [-]
+  double *theta_r;               // theta_r = smcmin [-]
+  double *vg_n;                  // Van Genuchten n [-]
+  double *vg_alpha;              // Van Genuchten alpha [1/cm]
+  double *Ksat;                  // Hydraulic conductivity [cm/hr]
+  double *field_capacity_psi;    // field capacity in capillary head [cm]
+  double *ponded_depth_max;      // maximum ponded depth of surface water [cm]
+
 };
 
 // nested structure of structures; main structure for the use in bmi

--- a/include/bmi_lgar.hxx
+++ b/include/bmi_lgar.hxx
@@ -67,9 +67,11 @@ public:
     // calibratable parameters
     this->calib_var_names[0] = "smcmax";
     this->calib_var_names[1] = "smcmin";
-    this->calib_var_names[2] = "van_genuchten_m";
+    this->calib_var_names[2] = "van_genuchten_n";
     this->calib_var_names[3] = "van_genuchten_alpha";
     this->calib_var_names[4] = "hydraulic_conductivity";
+    this->calib_var_names[5] = "field_capacity";
+    this->calib_var_names[6] = "ponded_depth_max";
   };
   
   void Initialize(std::string config_file);
@@ -132,7 +134,7 @@ private:
   struct model_state* state;
   static const int input_var_name_count  = 3;
   static const int output_var_name_count = 15;
-  static const int calib_var_name_count  = 5;
+  static const int calib_var_name_count  = 7;
   
   std::string input_var_names[input_var_name_count];
   std::string output_var_names[output_var_name_count];

--- a/realizations/realization_config_lasam.json
+++ b/realizations/realization_config_lasam.json
@@ -53,6 +53,15 @@
 					"precipitation_rate" : "P",
 					"potential_evapotranspiration_rate" : "PET"
 				    },
+					"model_params": {
+						"smcmax": [0.50, 0.49, 0.48],
+						"smcmin": [0.09, 0.08, 0.07],
+						"van_genuchten_n": [2.0, 2.1, 2.2],
+						"van_genuchten_alpha": [0.009, 0.008, 0.007],
+						"hydraulic_conductivity": [10.0, 11.0, 12.0],
+						"field_capacity": 333.3,
+						"ponded_depth_max": 1.1
+					},
 				    "output_variables" : [
 					"precipitation",
 					"potential_evapotranspiration",

--- a/realizations/realization_config_lasam.json
+++ b/realizations/realization_config_lasam.json
@@ -45,14 +45,23 @@
 				"name": "bmi_c++",
 				"params": {
 				    "model_type_name": "bmi_lasam",
-				    "library_file": "./extern/LGAR-C/LGAR-C/cmake_build/liblasambmi",
-				    "init_config": "./extern/LGAR-C/LGAR-C/configs/config_lasam_Phillipsburg.txt",
+				    "library_file": "./extern/LGAR-C/cmake_build/liblasambmi",
+				    "init_config": "./extern/LGAR-C/configs/config_lasam_Phillipsburg.txt",
 				    "allow_exceed_end_time": true,
 				    "main_output_variable": "precipitation_rate",
 				    "variables_names_map" : {
 					"precipitation_rate" : "P",
 					"potential_evapotranspiration_rate" : "PET"
 				    },
+					"model_params": {
+						"smcmax": [0.50, 0.49, 0.48],
+						"smcmin": [0.09, 0.08, 0.07],
+						"van_genuchten_n": [2.0, 2.1, 2.2],
+						"van_genuchten_alpha": [0.009, 0.008, 0.007],
+						"hydraulic_conductivity": [10.0, 11.0, 12.0],
+						"field_capacity": 333.3,
+						"ponded_depth_max": 1.1
+					},
 				    "output_variables" : [
 					"precipitation",
 					"potential_evapotranspiration",
@@ -73,7 +82,7 @@
 		}
             ],
             "forcing": {
-		"path" : "./extern/LGAR-C/LGAR-C/forcing/forcing_data_resampled_uniform_Phillipsburg.csv"
+		"path" : "./extern/LGAR-C/forcing/forcing_data_resampled_uniform_Phillipsburg.csv"
             }
         }
     }

--- a/realizations/realization_config_lasam.json
+++ b/realizations/realization_config_lasam.json
@@ -82,7 +82,7 @@
 		}
             ],
             "forcing": {
-		"path" : "./extern/LGAR-C/forcing/forcing_data_resampled_uniform_Phillipsburg.csv"
+		"path" : "./extern/LGAR-C/LGAR-C/forcing/forcing_data_resampled_uniform_Phillipsburg.csv"
             }
         }
     }

--- a/realizations/realization_config_lasam.json
+++ b/realizations/realization_config_lasam.json
@@ -45,23 +45,14 @@
 				"name": "bmi_c++",
 				"params": {
 				    "model_type_name": "bmi_lasam",
-				    "library_file": "./extern/LGAR-C/cmake_build/liblasambmi",
-				    "init_config": "./extern/LGAR-C/configs/config_lasam_Phillipsburg.txt",
+				    "library_file": "./extern/LGAR-C/LGAR-C/cmake_build/liblasambmi",
+				    "init_config": "./extern/LGAR-C/LGAR-C/configs/config_lasam_Phillipsburg.txt",
 				    "allow_exceed_end_time": true,
 				    "main_output_variable": "precipitation_rate",
 				    "variables_names_map" : {
 					"precipitation_rate" : "P",
 					"potential_evapotranspiration_rate" : "PET"
 				    },
-					"model_params": {
-						"smcmax": [0.50, 0.49, 0.48],
-						"smcmin": [0.09, 0.08, 0.07],
-						"van_genuchten_n": [2.0, 2.1, 2.2],
-						"van_genuchten_alpha": [0.009, 0.008, 0.007],
-						"hydraulic_conductivity": [10.0, 11.0, 12.0],
-						"field_capacity": 333.3,
-						"ponded_depth_max": 1.1
-					},
 				    "output_variables" : [
 					"precipitation",
 					"potential_evapotranspiration",

--- a/realizations/realization_config_lasam_sft.json
+++ b/realizations/realization_config_lasam_sft.json
@@ -80,23 +80,14 @@
 				"name": "bmi_c++",
 				"params": {
 				    "model_type_name": "bmi_lasam",
-				    "library_file": "./extern/LGAR-C/cmake_build/liblasambmi",
-				    "init_config": "./extern/LGAR-C/configs/config_lasam_sft_ngen.txt",
+				    "library_file": "./extern/LGAR-C/LGAR-C/cmake_build/liblasambmi",
+				    "init_config": "./extern/LGAR-C/LGAR-C/configs/config_lasam_sft_ngen.txt",
 				    "allow_exceed_end_time": true,
 				    "main_output_variable": "precipitation_rate",
 				    "variables_names_map" : {
 					"precipitation_rate" : "P",
 					"potential_evapotranspiration_rate" : "PET"
 				    },
-					"model_params": {
-						"smcmax": [0.50, 0.49, 0.48],
-						"smcmin": [0.09, 0.08, 0.07],
-						"van_genuchten_n": [2.0, 2.1, 2.2],
-						"van_genuchten_alpha": [0.009, 0.008, 0.007],
-						"hydraulic_conductivity": [10.0, 11.0, 12.0],
-						"field_capacity": 333.3,
-						"ponded_depth_max": 1.1
-					},
 				    "output_variables" : [
 					"precipitation",
 					"potential_evapotranspiration",
@@ -117,7 +108,7 @@
 		}
             ],
             "forcing": {
-		"path" : "./extern/LGAR-C/forcing/forcing_data_resampled_uniform_Phillipsburg.csv"
+		"path" : "./extern/LGAR-C/LGAR-C/forcing/forcing_data_resampled_uniform_Phillipsburg.csv"
             }
         }
     }

--- a/realizations/realization_config_lasam_sft.json
+++ b/realizations/realization_config_lasam_sft.json
@@ -88,6 +88,15 @@
 					"precipitation_rate" : "P",
 					"potential_evapotranspiration_rate" : "PET"
 				    },
+					"model_params": {
+						"smcmax": [0.50, 0.49, 0.48],
+						"smcmin": [0.09, 0.08, 0.07],
+						"van_genuchten_n": [2.0, 2.1, 2.2],
+						"van_genuchten_alpha": [0.009, 0.008, 0.007],
+						"hydraulic_conductivity": [10.0, 11.0, 12.0],
+						"field_capacity": 333.3,
+						"ponded_depth_max": 1.1
+					},
 				    "output_variables" : [
 					"precipitation",
 					"potential_evapotranspiration",

--- a/realizations/realization_config_lasam_sft.json
+++ b/realizations/realization_config_lasam_sft.json
@@ -80,14 +80,23 @@
 				"name": "bmi_c++",
 				"params": {
 				    "model_type_name": "bmi_lasam",
-				    "library_file": "./extern/LGAR-C/LGAR-C/cmake_build/liblasambmi",
-				    "init_config": "./extern/LGAR-C/LGAR-C/configs/config_lasam_sft_ngen.txt",
+				    "library_file": "./extern/LGAR-C/cmake_build/liblasambmi",
+				    "init_config": "./extern/LGAR-C/configs/config_lasam_sft_ngen.txt",
 				    "allow_exceed_end_time": true,
 				    "main_output_variable": "precipitation_rate",
 				    "variables_names_map" : {
 					"precipitation_rate" : "P",
 					"potential_evapotranspiration_rate" : "PET"
 				    },
+					"model_params": {
+						"smcmax": [0.50, 0.49, 0.48],
+						"smcmin": [0.09, 0.08, 0.07],
+						"van_genuchten_n": [2.0, 2.1, 2.2],
+						"van_genuchten_alpha": [0.009, 0.008, 0.007],
+						"hydraulic_conductivity": [10.0, 11.0, 12.0],
+						"field_capacity": 333.3,
+						"ponded_depth_max": 1.1
+					},
 				    "output_variables" : [
 					"precipitation",
 					"potential_evapotranspiration",
@@ -108,7 +117,7 @@
 		}
             ],
             "forcing": {
-		"path" : "./extern/LGAR-C/LGAR-C/forcing/forcing_data_resampled_uniform_Phillipsburg.csv"
+		"path" : "./extern/LGAR-C/forcing/forcing_data_resampled_uniform_Phillipsburg.csv"
             }
         }
     }

--- a/realizations/realization_config_lasam_smp.json
+++ b/realizations/realization_config_lasam_smp.json
@@ -103,7 +103,7 @@
 		}
             ],
             "forcing": {
-		"path" : "./extern/LGAR-C/forcing/forcing_data_resampled_uniform_Phillipsburg.csv"
+		"path" : "./extern/LGAR-C/LGAR-C/forcing/forcing_data_resampled_uniform_Phillipsburg.csv"
             }
         }
     }

--- a/realizations/realization_config_lasam_smp.json
+++ b/realizations/realization_config_lasam_smp.json
@@ -74,6 +74,15 @@
 					"precipitation_rate" : "P",
 					"potential_evapotranspiration_rate" : "PET"
 				    },
+					"model_params": {
+						"smcmax": [0.50, 0.49, 0.48],
+						"smcmin": [0.09, 0.08, 0.07],
+						"van_genuchten_n": [2.0, 2.1, 2.2],
+						"van_genuchten_alpha": [0.009, 0.008, 0.007],
+						"hydraulic_conductivity": [10.0, 11.0, 12.0],
+						"field_capacity": 333.3,
+						"ponded_depth_max": 1.1
+					},
 				    "output_variables" : [
 					"precipitation",
 					"potential_evapotranspiration",

--- a/realizations/realization_config_lasam_smp.json
+++ b/realizations/realization_config_lasam_smp.json
@@ -66,23 +66,14 @@
 				"name": "bmi_c++",
 				"params": {
 				    "model_type_name": "bmi_lasam",
-				    "library_file": "./extern/LGAR-C/cmake_build/liblasambmi",
-				    "init_config": "./extern/LGAR-C/configs/config_lasam_Phillipsburg.txt",
+				    "library_file": "./extern/LGAR-C/LGAR-C/cmake_build/liblasambmi",
+				    "init_config": "./extern/LGAR-C/LGAR-C/configs/config_lasam_Phillipsburg.txt",
 				    "allow_exceed_end_time": true,
 				    "main_output_variable": "precipitation_rate",
 				    "variables_names_map" : {
 					"precipitation_rate" : "P",
 					"potential_evapotranspiration_rate" : "PET"
 				    },
-					"model_params": {
-						"smcmax": [0.50, 0.49, 0.48],
-						"smcmin": [0.09, 0.08, 0.07],
-						"van_genuchten_n": [2.0, 2.1, 2.2],
-						"van_genuchten_alpha": [0.009, 0.008, 0.007],
-						"hydraulic_conductivity": [10.0, 11.0, 12.0],
-						"field_capacity": 333.3,
-						"ponded_depth_max": 1.1
-					},
 				    "output_variables" : [
 					"precipitation",
 					"potential_evapotranspiration",

--- a/realizations/realization_config_lasam_smp.json
+++ b/realizations/realization_config_lasam_smp.json
@@ -66,14 +66,23 @@
 				"name": "bmi_c++",
 				"params": {
 				    "model_type_name": "bmi_lasam",
-				    "library_file": "./extern/LGAR-C/LGAR-C/cmake_build/liblasambmi",
-				    "init_config": "./extern/LGAR-C/LGAR-C/configs/config_lasam_Phillipsburg.txt",
+				    "library_file": "./extern/LGAR-C/cmake_build/liblasambmi",
+				    "init_config": "./extern/LGAR-C/configs/config_lasam_Phillipsburg.txt",
 				    "allow_exceed_end_time": true,
 				    "main_output_variable": "precipitation_rate",
 				    "variables_names_map" : {
 					"precipitation_rate" : "P",
 					"potential_evapotranspiration_rate" : "PET"
 				    },
+					"model_params": {
+						"smcmax": [0.50, 0.49, 0.48],
+						"smcmin": [0.09, 0.08, 0.07],
+						"van_genuchten_n": [2.0, 2.1, 2.2],
+						"van_genuchten_alpha": [0.009, 0.008, 0.007],
+						"hydraulic_conductivity": [10.0, 11.0, 12.0],
+						"field_capacity": 333.3,
+						"ponded_depth_max": 1.1
+					},
 				    "output_variables" : [
 					"precipitation",
 					"potential_evapotranspiration",
@@ -94,7 +103,7 @@
 		}
             ],
             "forcing": {
-		"path" : "./extern/LGAR-C/LGAR-C/forcing/forcing_data_resampled_uniform_Phillipsburg.csv"
+		"path" : "./extern/LGAR-C/forcing/forcing_data_resampled_uniform_Phillipsburg.csv"
             }
         }
     }

--- a/src/aet.cxx
+++ b/src/aet.cxx
@@ -4,7 +4,7 @@
 #include "../include/all.hxx"
 
 //################################################################################
-/* authors : Fred Ogden and Ahmad Jan
+/* authors : Fred Ogden and Ahmad Jan and Peter La Follette
    year    : 2022
    the code computes actual evapotranspiration given PET.
    It uses an S-shaped function used in HYDRUS-1D (Simunek & Sejna, 2018).
@@ -14,7 +14,7 @@
 //################################################################################
 
 
-extern double calc_aet(double PET_timestep_cm, double time_step_h, double wilting_point_psi_cm,
+extern double calc_aet(double PET_timestep_cm, double time_step_h, double wilting_point_psi_cm, double field_capacity_psi_cm,
 		       int *soil_type, double AET_thresh_Theta, double AET_expon,
 		       struct wetting_front* head, struct soil_properties_ *soil_properties)
 {
@@ -44,8 +44,8 @@ extern double calc_aet(double PET_timestep_cm, double time_step_h, double wiltin
   vg_n      = soil_properties[soil_num].vg_n;
 
   // compute theta field capacity
-  double head_at_which_PET_equals_AET_cm = 340.9;//*10/33; //340.9 is 0.33 atm, expressed in water depth, which is a good field capacity for most soils.
-  //Coarser soils like sand will have a field capacity of 0.1 atm or so.
+  double head_at_which_PET_equals_AET_cm = field_capacity_psi_cm; //340.9 is 0.33 atm, expressed in water depth, which is a good field capacity for most soils.
+  //Coarser soils like sand will have a field capacity of 0.1 atm or so, which would be 103.3 cm.
   double theta_fc = calc_theta_from_h(head_at_which_PET_equals_AET_cm, vg_a,vg_m, vg_n, theta_e, theta_r);
   
   double wp_head_theta = calc_theta_from_h(wilting_point_psi_cm, vg_a,vg_m, vg_n, theta_e, theta_r);

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -115,6 +115,7 @@ Update()
   double subtimestep_h = state->lgar_bmi_params.timestep_h;
   int nint = state->lgar_bmi_params.nint;
   double wilting_point_psi_cm = state->lgar_bmi_params.wilting_point_psi_cm;
+  double field_capacity_psi_cm = state->lgar_bmi_params.field_capacity_psi_cm;
   bool use_closed_form_G = state->lgar_bmi_params.use_closed_form_G; 
 
   // constant value used in the AET function
@@ -192,7 +193,7 @@ Update()
 
     // Calculate AET from PET if PET is non-zero
     if (PET_subtimestep_cm_per_h > 0.0) {
-      AET_subtimestep_cm = calc_aet(PET_subtimestep_cm_per_h, subtimestep_h, wilting_point_psi_cm,
+      AET_subtimestep_cm = calc_aet(PET_subtimestep_cm_per_h, subtimestep_h, wilting_point_psi_cm, field_capacity_psi_cm,
                                     state->lgar_bmi_params.layer_soil_type, AET_thresh_Theta, AET_expon,
                                     state->head, state->soil_properties);
     }

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -521,7 +521,7 @@ update_calibratable_parameters()
       std::cerr<<"| soil_type = "<< soil <<", layer = "<<layer_num
 	       <<", smcmax = "   << state->soil_properties[soil].theta_e
 	       <<", smcmin = "   << state->soil_properties[soil].theta_r
-	       <<", vg_m = "     << state->soil_properties[soil].vg_m
+	       <<", vg_n = "     << state->soil_properties[soil].vg_n
 	       <<", vg_alpha = " << state->soil_properties[soil].vg_alpha_per_cm
 	       <<", Ksat = "     << state->soil_properties[soil].Ksat_cm_per_h
 	       <<", theta = "   << current->theta <<"\n";
@@ -543,7 +543,7 @@ update_calibratable_parameters()
       std::cerr<<"| soil_type = "<< soil <<", layer = "<<layer_num
 	       <<", smcmax = "   << state->soil_properties[soil].theta_e
 	       <<", smcmin = "   << state->soil_properties[soil].theta_r
-	       <<", vg_m = "     << state->soil_properties[soil].vg_m
+	       <<", vg_n = "     << state->soil_properties[soil].vg_n
 	       <<", vg_alpha = " << state->soil_properties[soil].vg_alpha_per_cm
 	       <<", Ksat = "     << state->soil_properties[soil].Ksat_cm_per_h
 	       <<", theta = "   << current->theta <<"\n";
@@ -590,7 +590,7 @@ GetVarGrid(std::string name)
   else if (name.compare("mass_balance") == 0)
     return 1;
   else if (name.compare("soil_depth_layers") == 0  || name.compare("smcmax") == 0 || name.compare("smcmin") == 0
-	   || name.compare("van_genuchten_m") == 0 || name.compare("van_genuchten_alpha") == 0
+	   || name.compare("van_genuchten_m") == 0 || name.compare("van_genuchten_alpha") == 0 || name.compare("van_genuchten_n") == 0 
 	   || name.compare("hydraulic_conductivity") == 0) // array of doubles (fixed length)
     return 2;
   else if (name.compare("soil_moisture_wetting_fronts") == 0 || name.compare("soil_depth_wetting_fronts") == 0) // array of doubles (dynamic length)
@@ -807,7 +807,7 @@ GetValuePtr (std::string name)
     return (void*)this->state->lgar_calib_params.theta_e;
   else if (name.compare("smcmin") == 0)
     return (void*)this->state->lgar_calib_params.theta_r;
-  else if (name.compare("van_genuchten_m") == 0)
+  else if (name.compare("van_genuchten_n") == 0)
     return (void*)this->state->lgar_calib_params.vg_n;
   else if (name.compare("van_genuchten_alpha") == 0)
     return (void*)this->state->lgar_calib_params.vg_alpha;

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -529,8 +529,8 @@ update_calibratable_parameters()
     
     state->soil_properties[soil].theta_e = state->lgar_calib_params.theta_e[layer_num-1];
     state->soil_properties[soil].theta_r = state->lgar_calib_params.theta_r[layer_num-1];
-    state->soil_properties[soil].vg_m    = state->lgar_calib_params.vg_m[layer_num-1];
-    state->soil_properties[soil].vg_n    = 1.0/(1.0 - state->soil_properties[soil].vg_m);
+    state->soil_properties[soil].vg_n    = state->lgar_calib_params.vg_n[layer_num-1];
+    state->soil_properties[soil].vg_m    = 1.0 - 1.0/state->soil_properties[soil].vg_n;
     state->soil_properties[soil].vg_alpha_per_cm = state->lgar_calib_params.vg_alpha[layer_num-1];
     state->soil_properties[soil].Ksat_cm_per_h   = state->lgar_calib_params.Ksat[layer_num-1];
     

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -820,9 +820,9 @@ GetValuePtr (std::string name)
   else if (name.compare("hydraulic_conductivity") == 0)
     return (void*)this->state->lgar_calib_params.Ksat;
   else if (name.compare("ponded_depth_max") == 0)
-    return (void*)(&state->lgar_bmi_params.ponded_depth_max_cm);
+    return (void*)&this->state->lgar_calib_params.ponded_depth_max;
   else if (name.compare("field_capacity") == 0)
-    return (void*)(&state->lgar_bmi_params.field_capacity_psi_cm);
+    return (void*)&this->state->lgar_calib_params.field_capacity_psi;
   else {
     std::stringstream errMsg;
     errMsg << "variable "<< name << " does not exist";

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -535,6 +535,8 @@ update_calibratable_parameters()
     state->soil_properties[soil].vg_m    = 1.0 - 1.0/state->soil_properties[soil].vg_n;
     state->soil_properties[soil].vg_alpha_per_cm = state->lgar_calib_params.vg_alpha[layer_num-1];
     state->soil_properties[soil].Ksat_cm_per_h   = state->lgar_calib_params.Ksat[layer_num-1];
+    state->lgar_bmi_params.field_capacity_psi_cm = state->lgar_calib_params.field_capacity_psi;
+    state->lgar_bmi_params.ponded_depth_max_cm   = state->lgar_calib_params.ponded_depth_max;
     
     current->theta = calc_theta_from_h(current->psi_cm, state->soil_properties[soil].vg_alpha_per_cm,
 				       state->soil_properties[soil].vg_m, state->soil_properties[soil].vg_n,

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -808,7 +808,7 @@ GetValuePtr (std::string name)
   else if (name.compare("smcmin") == 0)
     return (void*)this->state->lgar_calib_params.theta_r;
   else if (name.compare("van_genuchten_m") == 0)
-    return (void*)this->state->lgar_calib_params.vg_m;
+    return (void*)this->state->lgar_calib_params.vg_n;
   else if (name.compare("van_genuchten_alpha") == 0)
     return (void*)this->state->lgar_calib_params.vg_alpha;
   else if (name.compare("hydraulic_conductivity") == 0)

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -820,9 +820,9 @@ GetValuePtr (std::string name)
   else if (name.compare("hydraulic_conductivity") == 0)
     return (void*)this->state->lgar_calib_params.Ksat;
   else if (name.compare("ponded_depth_max") == 0)
-    return (void*)&this->state->lgar_calib_params.field_capacity_psi;
-  else if (name.compare("field_capacity") == 0)
     return (void*)&this->state->lgar_calib_params.ponded_depth_max;
+  else if (name.compare("field_capacity") == 0)
+    return (void*)&this->state->lgar_calib_params.field_capacity_psi;
   else {
     std::stringstream errMsg;
     errMsg << "variable "<< name << " does not exist";

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -524,6 +524,8 @@ update_calibratable_parameters()
 	       <<", vg_n = "     << state->soil_properties[soil].vg_n
 	       <<", vg_alpha = " << state->soil_properties[soil].vg_alpha_per_cm
 	       <<", Ksat = "     << state->soil_properties[soil].Ksat_cm_per_h
+         <<", field_capacity_psi = "     << state->lgar_bmi_params.field_capacity_psi_cm
+         <<", ponded_depth_max = "     << state->lgar_bmi_params.ponded_depth_max_cm
 	       <<", theta = "   << current->theta <<"\n";
     }
     
@@ -533,6 +535,8 @@ update_calibratable_parameters()
     state->soil_properties[soil].vg_m    = 1.0 - 1.0/state->soil_properties[soil].vg_n;
     state->soil_properties[soil].vg_alpha_per_cm = state->lgar_calib_params.vg_alpha[layer_num-1];
     state->soil_properties[soil].Ksat_cm_per_h   = state->lgar_calib_params.Ksat[layer_num-1];
+    state->lgar_bmi_params.field_capacity_psi_cm = state->lgar_calib_params.field_capacity_psi;
+    state->lgar_bmi_params.ponded_depth_max_cm   = state->lgar_calib_params.ponded_depth_max;
     
     current->theta = calc_theta_from_h(current->psi_cm, state->soil_properties[soil].vg_alpha_per_cm,
 				       state->soil_properties[soil].vg_m, state->soil_properties[soil].vg_n,
@@ -546,6 +550,8 @@ update_calibratable_parameters()
 	       <<", vg_n = "     << state->soil_properties[soil].vg_n
 	       <<", vg_alpha = " << state->soil_properties[soil].vg_alpha_per_cm
 	       <<", Ksat = "     << state->soil_properties[soil].Ksat_cm_per_h
+         <<", field_capacity_psi = "     << state->lgar_bmi_params.field_capacity_psi_cm
+         <<", ponded_depth_max = "     << state->lgar_bmi_params.ponded_depth_max_cm
 	       <<", theta = "   << current->theta <<"\n";
     }
     
@@ -582,7 +588,7 @@ GetVarGrid(std::string name)
 	   || name.compare("actual_evapotranspiration") == 0) // double
     return 1;
   else if (name.compare("surface_runoff") == 0 || name.compare("giuh_runoff") == 0
-	   || name.compare("soil_storage") == 0) // double
+	   || name.compare("soil_storage") == 0 || name.compare("field_capacity") == 0 || name.compare("ponded_depth_max") == 0)// double
     return 1;
   else if (name.compare("total_discharge") == 0 || name.compare("infiltration") == 0
 	   || name.compare("percolation") == 0  || name.compare("groundwater_to_stream_recharge") == 0) // double
@@ -813,6 +819,10 @@ GetValuePtr (std::string name)
     return (void*)this->state->lgar_calib_params.vg_alpha;
   else if (name.compare("hydraulic_conductivity") == 0)
     return (void*)this->state->lgar_calib_params.Ksat;
+  else if (name.compare("ponded_depth_max") == 0)
+    return (void*)&this->state->lgar_calib_params.field_capacity_psi;
+  else if (name.compare("field_capacity") == 0)
+    return (void*)&this->state->lgar_calib_params.ponded_depth_max;
   else {
     std::stringstream errMsg;
     errMsg << "variable "<< name << " does not exist";

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -535,8 +535,6 @@ update_calibratable_parameters()
     state->soil_properties[soil].vg_m    = 1.0 - 1.0/state->soil_properties[soil].vg_n;
     state->soil_properties[soil].vg_alpha_per_cm = state->lgar_calib_params.vg_alpha[layer_num-1];
     state->soil_properties[soil].Ksat_cm_per_h   = state->lgar_calib_params.Ksat[layer_num-1];
-    state->lgar_bmi_params.field_capacity_psi_cm = state->lgar_calib_params.field_capacity_psi;
-    state->lgar_bmi_params.ponded_depth_max_cm   = state->lgar_calib_params.ponded_depth_max;
     
     current->theta = calc_theta_from_h(current->psi_cm, state->soil_properties[soil].vg_alpha_per_cm,
 				       state->soil_properties[soil].vg_m, state->soil_properties[soil].vg_n,
@@ -820,9 +818,9 @@ GetValuePtr (std::string name)
   else if (name.compare("hydraulic_conductivity") == 0)
     return (void*)this->state->lgar_calib_params.Ksat;
   else if (name.compare("ponded_depth_max") == 0)
-    return (void*)&this->state->lgar_calib_params.ponded_depth_max;
+    return (void*)(&state->lgar_bmi_params.ponded_depth_max_cm);
   else if (name.compare("field_capacity") == 0)
-    return (void*)&this->state->lgar_calib_params.field_capacity_psi;
+    return (void*)(&state->lgar_bmi_params.field_capacity_psi_cm);
   else {
     std::stringstream errMsg;
     errMsg << "variable "<< name << " does not exist";

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -510,23 +510,21 @@ update_calibratable_parameters()
   
   double volstart_before = lgar_calc_mass_bal(state->lgar_bmi_params.cum_layer_thickness_cm, state->head);
 
-  for (int i=0; i<state->lgar_bmi_params.num_wetting_fronts; i++) {
+  for (int i=0; i<state->lgar_bmi_params.num_wetting_fronts; i++) {//first we update the parameters that depend on soil layer, for each layer
     layer_num  = current->layer_num;
     soil = state->lgar_bmi_params.layer_soil_type[layer_num];
     
     assert (current != NULL);
 
     if (verbosity.compare("high") == 0 || verbosity.compare("low") == 0) {
-      std::cerr<<"----------- Calibratable parameters (initial values) ----------- \n";
+      std::cerr<<"----------- Calibratable parameters depending on soil layer (initial values) ----------- \n";
       std::cerr<<"| soil_type = "<< soil <<", layer = "<<layer_num
 	       <<", smcmax = "   << state->soil_properties[soil].theta_e
 	       <<", smcmin = "   << state->soil_properties[soil].theta_r
 	       <<", vg_n = "     << state->soil_properties[soil].vg_n
 	       <<", vg_alpha = " << state->soil_properties[soil].vg_alpha_per_cm
 	       <<", Ksat = "     << state->soil_properties[soil].Ksat_cm_per_h
-         <<", field_capacity_psi = "     << state->lgar_bmi_params.field_capacity_psi_cm
-         <<", ponded_depth_max = "     << state->lgar_bmi_params.ponded_depth_max_cm
-	       <<", theta = "   << current->theta <<"\n";
+	       <<", theta = "    << current->theta <<"\n";
     }
     
     state->soil_properties[soil].theta_e = state->lgar_calib_params.theta_e[layer_num-1];
@@ -535,27 +533,39 @@ update_calibratable_parameters()
     state->soil_properties[soil].vg_m    = 1.0 - 1.0/state->soil_properties[soil].vg_n;
     state->soil_properties[soil].vg_alpha_per_cm = state->lgar_calib_params.vg_alpha[layer_num-1];
     state->soil_properties[soil].Ksat_cm_per_h   = state->lgar_calib_params.Ksat[layer_num-1];
-    state->lgar_bmi_params.field_capacity_psi_cm = state->lgar_calib_params.field_capacity_psi;
-    state->lgar_bmi_params.ponded_depth_max_cm   = state->lgar_calib_params.ponded_depth_max;
     
     current->theta = calc_theta_from_h(current->psi_cm, state->soil_properties[soil].vg_alpha_per_cm,
 				       state->soil_properties[soil].vg_m, state->soil_properties[soil].vg_n,
 				       state->soil_properties[soil].theta_e, state->soil_properties[soil].theta_r);
 
     if (verbosity.compare("high") == 0 || verbosity.compare("low") == 0) {
-      std::cerr<<"----------- Calibratable parameters (updated values) ----------- \n";
+      std::cerr<<"----------- Calibratable parameters depending on soil layer (updated values) ----------- \n";
       std::cerr<<"| soil_type = "<< soil <<", layer = "<<layer_num
 	       <<", smcmax = "   << state->soil_properties[soil].theta_e
 	       <<", smcmin = "   << state->soil_properties[soil].theta_r
 	       <<", vg_n = "     << state->soil_properties[soil].vg_n
 	       <<", vg_alpha = " << state->soil_properties[soil].vg_alpha_per_cm
 	       <<", Ksat = "     << state->soil_properties[soil].Ksat_cm_per_h
-         <<", field_capacity_psi = "     << state->lgar_bmi_params.field_capacity_psi_cm
-         <<", ponded_depth_max = "     << state->lgar_bmi_params.ponded_depth_max_cm
-	       <<", theta = "   << current->theta <<"\n";
+	       <<", theta = "    << current->theta <<"\n";
     }
     
     current = current->next;
+  }
+
+  //next we update the parameters that apply to the whole model domain and do not depend on soil layer
+  if (verbosity.compare("high") == 0 || verbosity.compare("low") == 0) {
+    std::cerr<<"----------- Calibratable parameters independent of soil layer (initial values) ----------- \n";
+    std::cerr<<"field_capacity_psi = "   << state->lgar_bmi_params.field_capacity_psi_cm
+      <<", ponded_depth_max = "     << state->lgar_bmi_params.ponded_depth_max_cm <<"\n";
+  }
+
+  state->lgar_bmi_params.field_capacity_psi_cm = state->lgar_calib_params.field_capacity_psi;
+  state->lgar_bmi_params.ponded_depth_max_cm   = state->lgar_calib_params.ponded_depth_max;
+
+  if (verbosity.compare("high") == 0 || verbosity.compare("low") == 0) {
+    std::cerr<<"----------- Calibratable parameters independent of soil layer (updated values) ----------- \n";
+    std::cerr<<"field_capacity_psi = "   << state->lgar_bmi_params.field_capacity_psi_cm
+      <<", ponded_depth_max = "     << state->lgar_bmi_params.ponded_depth_max_cm <<"\n";
   }
   
   if (verbosity.compare("high") == 0)

--- a/src/lgar.cxx
+++ b/src/lgar.cxx
@@ -159,6 +159,7 @@ extern void lgar_initialize(string config_file, struct model_state *state)
   @param frozen_factor          : frozen factor causing the hydraulic conductivity to decrease due to frozen soil
                                   (when coupled to soil freeze thaw model)
   @param wilting_point_psi_cm   : wilting point (the amount of water not available for plants or not accessible by plants)
+  @param field_capacity_psi_cm  : field capacity, represented with a capillary head (head above which drainage is much faster)
   @param ponded_depth_cm        : amount of water on the surface not available for surface drainage (initialized to zero)
   @param ponded_depth_max cm    : maximum amount of water on the surface not available for surface drainage (default is zero)
   @param nint                   : number of trapezoids used in integrating the Geff function (set to 120)
@@ -210,18 +211,19 @@ extern void InitFromConfigFile(string config_file, struct model_state *state)
   state->lgar_bmi_params.sft_coupled       = false;
   state->lgar_bmi_params.use_closed_form_G = false;
   
-  bool is_layer_thickness_set      = false;
-  bool is_initial_psi_set          = false;
-  bool is_timestep_set             = false;
-  bool is_endtime_set              = false;
-  bool is_forcing_resolution_set   = false;
-  bool is_layer_soil_type_set      = false;
-  bool is_wilting_point_psi_cm_set = false;
-  bool is_soil_params_file_set     = false;
-  bool is_max_soil_types_set       = false;
-  bool is_giuh_ordinates_set       = false;
-  bool is_soil_z_set               = false;
-  bool is_ponded_depth_max_cm_set  = false;
+  bool is_layer_thickness_set       = false;
+  bool is_initial_psi_set           = false;
+  bool is_timestep_set              = false;
+  bool is_endtime_set               = false;
+  bool is_forcing_resolution_set    = false;
+  bool is_layer_soil_type_set       = false;
+  bool is_wilting_point_psi_cm_set  = false;
+  bool is_field_capacity_psi_cm_set = false;
+  bool is_soil_params_file_set      = false;
+  bool is_max_soil_types_set        = false;
+  bool is_giuh_ordinates_set        = false;
+  bool is_soil_z_set                = false;
+  bool is_ponded_depth_max_cm_set   = false;
 
   string soil_params_file;
 
@@ -363,6 +365,17 @@ extern void InitFromConfigFile(string config_file, struct model_state *state)
 
       if (verbosity.compare("high") == 0) {
 	std::cerr<<"Wilting point Psi [cm] : "<<state->lgar_bmi_params.wilting_point_psi_cm<<"\n";
+	std::cerr<<"          *****         \n";
+      }
+
+      continue;
+    }
+    else if (param_key == "field_capacity_psi") {
+      state->lgar_bmi_params.field_capacity_psi_cm = stod(param_value);
+      is_field_capacity_psi_cm_set = true;
+
+      if (verbosity.compare("high") == 0) {
+	std::cerr<<"Field capacity Psi [cm] : "<<state->lgar_bmi_params.field_capacity_psi_cm<<"\n";
 	std::cerr<<"          *****         \n";
       }
 
@@ -522,6 +535,7 @@ extern void InitFromConfigFile(string config_file, struct model_state *state)
     state->soil_properties = new soil_properties_[state->lgar_bmi_params.num_soil_types+1];
     int num_soil_types = state->lgar_bmi_params.num_soil_types;
     double wilting_point_psi_cm = state->lgar_bmi_params.wilting_point_psi_cm;
+    double field_capacity_psi_cm = state->lgar_bmi_params.field_capacity_psi_cm;
     int max_num_soil_in_file = lgar_read_vG_param_file(soil_params_file.c_str(), num_soil_types,
 						       wilting_point_psi_cm, state->soil_properties);
 
@@ -572,7 +586,13 @@ extern void InitFromConfigFile(string config_file, struct model_state *state)
 
   if(!is_wilting_point_psi_cm_set) {
     stringstream errMsg;
-    errMsg << "The configuration file \'" << config_file <<"\' does not set wilting_point_psi. \n";
+    errMsg << "The configuration file \'" << config_file <<"\' does not set wilting_point_psi. \n Recommended value of 15495.0[cm], corresponding to 15 atm. \n";
+    throw runtime_error(errMsg.str());
+  }
+
+  if(!is_field_capacity_psi_cm_set) {
+    stringstream errMsg;
+    errMsg << "The configuration file \'" << config_file <<"\' does not set field_capacity_psi. \n Recommended value of 340.9[cm] for most soils, corresponding to 1/3 atm, or 103.3[cm] for sands, corresponding to 1/10 atm. \n";
     throw runtime_error(errMsg.str());
   }
 

--- a/src/lgar.cxx
+++ b/src/lgar.cxx
@@ -86,7 +86,7 @@ extern void lgar_initialize(string config_file, struct model_state *state)
   // initialize array for holding calibratable parameters
   state->lgar_calib_params.theta_e  = new double[state->lgar_bmi_params.num_layers];
   state->lgar_calib_params.theta_r  = new double[state->lgar_bmi_params.num_layers];
-  state->lgar_calib_params.vg_m     = new double[state->lgar_bmi_params.num_layers];
+  state->lgar_calib_params.vg_n     = new double[state->lgar_bmi_params.num_layers];
   state->lgar_calib_params.vg_alpha = new double[state->lgar_bmi_params.num_layers];
   state->lgar_calib_params.Ksat     = new double[state->lgar_bmi_params.num_layers];
   
@@ -103,7 +103,7 @@ extern void lgar_initialize(string config_file, struct model_state *state)
 
     state->lgar_calib_params.theta_e[i]  = state->soil_properties[soil].theta_e;
     state->lgar_calib_params.theta_r[i]  = state->soil_properties[soil].theta_r;
-    state->lgar_calib_params.vg_m[i]     = state->soil_properties[soil].vg_m;
+    state->lgar_calib_params.vg_n[i]     = state->soil_properties[soil].vg_n;
     state->lgar_calib_params.vg_alpha[i] = state->soil_properties[soil].vg_alpha_per_cm;
     state->lgar_calib_params.Ksat[i]     = state->soil_properties[soil].Ksat_cm_per_h;
     

--- a/src/lgar.cxx
+++ b/src/lgar.cxx
@@ -92,6 +92,9 @@ extern void lgar_initialize(string config_file, struct model_state *state)
   
   // initialize thickness/depth and soil moisture of wetting fronts (used for model coupling)
   // also initialize calibratable parameters
+  state->lgar_calib_params.field_capacity_psi = state->lgar_bmi_params.field_capacity_psi_cm;
+  state->lgar_calib_params.ponded_depth_max = state->lgar_bmi_params.ponded_depth_max_cm;
+
   struct wetting_front *current = state->head;
   for (int i=0; i<state->lgar_bmi_params.num_wetting_fronts; i++) {
     assert (current != NULL);

--- a/tests/configs/config_lasam_synth_0.txt
+++ b/tests/configs/config_lasam_synth_0.txt
@@ -9,5 +9,6 @@ forcing_resolution=3600[sec]
 layer_soil_type=13,14,15
 max_soil_types=15
 wilting_point_psi=15495.0[cm]
+field_capacity_psi=340.9[cm]
 giuh_ordinates=0.06,0.51,0.28,0.12,0.03
 ponded_depth_max=1.0[cm]

--- a/tests/configs/config_lasam_synth_1.txt
+++ b/tests/configs/config_lasam_synth_1.txt
@@ -9,4 +9,5 @@ forcing_resolution=300[sec]
 layer_soil_type=13,14,15
 max_soil_types=25
 wilting_point_psi=15495.0[cm]
+field_capacity_psi=340.9[cm]
 giuh_ordinates=0.0,0.0,0.0,0.0,0.0

--- a/tests/configs/config_lasam_synth_2.txt
+++ b/tests/configs/config_lasam_synth_2.txt
@@ -9,4 +9,5 @@ forcing_resolution=300[sec]
 layer_soil_type=13,14,15
 max_soil_types=25
 wilting_point_psi=15495.0[cm]
+field_capacity_psi=340.9[cm]
 giuh_ordinates=0.0,0.0,0.0,0.0,0.0

--- a/tests/configs/unittest.txt
+++ b/tests/configs/unittest.txt
@@ -9,5 +9,6 @@ forcing_resolution=3600[sec]
 layer_soil_type=13,14,15
 max_soil_types=15
 wilting_point_psi=15495.0[cm]
+field_capacity_psi=340.9[cm]
 giuh_ordinates=0.06,0.51,0.28,0.12,0.03
 calib_params=true

--- a/tests/configs/unittest.txt
+++ b/tests/configs/unittest.txt
@@ -6,6 +6,7 @@ initial_psi=2000.0[cm]
 timestep=300[sec]
 endtime=1.0[hr]
 forcing_resolution=3600[sec]
+ponded_depth_max=0[cm]
 layer_soil_type=13,14,15
 max_soil_types=15
 wilting_point_psi=15495.0[cm]

--- a/tests/main_unit_test_bmi.cxx
+++ b/tests/main_unit_test_bmi.cxx
@@ -453,8 +453,8 @@ int main(int argc, char *argv[])
 
   // Benchmark values of wetting fronts depth and moisture (b is for benchmark)
   //std::vector<double> depth_wf_b = {1.873813, 44.00,175.0, 200.0}; // in cm
-  std::vector<double> depth_wf_b = {4.55332255489760840, 44.00,175.0, 200.0}; // in cm
-  std::vector<double> theta_wf_b = {0.21414942004659104, 0.172703948143618, 0.252113867764474, 0.179593529195751};
+  std::vector<double> depth_wf_b = {4.55355239489608365, 44.00,175.0, 200.0}; // in cm
+  std::vector<double> theta_wf_b = {0.21371581122514613, 0.17270389607163267, 0.25211383152603861, 0.17959348005962811};
 
   int m_to_cm = 100;
   int m_to_mm = 1000;
@@ -518,7 +518,7 @@ int main(int argc, char *argv[])
 
   // check total infiltration, AET, and PET.
   double infiltration_check_mm = 1.896;  // in mm
-  double AET_check_mm          = 0.00922002885520525; // in mm
+  double AET_check_mm          = 0.02980092620558239; // in mm
   double PET_check_mm          = 0.104; // in mm
   double infiltration_computed = 0.0;
   double PET_computed          = 0.0;
@@ -528,7 +528,6 @@ int main(int argc, char *argv[])
   model.GetValue("potential_evapotranspiration", &PET_computed);
   model.GetValue("actual_evapotranspiration", &AET_computed);
 
-  
   std::cout<<GREEN<<"\n";
   std::cout<<"| *************************************** \n";
   std::cout<<"| All BMI Tests passed? "<< passed <<"\n";
@@ -589,8 +588,8 @@ int main(int argc, char *argv[])
   double vg_n_set[]     = {1.44260592334, 1.14965918354, 1.39051695249};
   double vg_alpha_set[] = {0.0021297, 0.0073272, 0.0027454};
   double Ksat_set[]     = {0.446, 0.0743, 0.415};
-  double field_capacity_set = 340.9;
-  double ponded_depth_max_set = 0.0;
+  double field_capacity_set = 103.3;
+  double ponded_depth_max_set = 1.0;
  
   // Get the initial values set through the config file
   model_calib.GetValue("smcmax", &smcmax[0]);

--- a/tests/main_unit_test_bmi.cxx
+++ b/tests/main_unit_test_bmi.cxx
@@ -579,35 +579,35 @@ int main(int argc, char *argv[])
 
   // Testing Calibratable parameters
   double *smcmax   = new double[num_layers];
-  double *vg_m     = new double[num_layers];
+  double *vg_n     = new double[num_layers];
   double *vg_alpha = new double[num_layers];
   double *Ksat     = new double[num_layers];
 
   double smcmax_set[]   = {0.3513, 0.3773, 0.3617};
-  double vg_m_set[]     = {0.30681, 0.130177, 0.280843};
+  double vg_n_set[]     = {1.44260592334, 1.14965918354, 1.39051695249};
   double vg_alpha_set[] = {0.0021297, 0.0073272, 0.0027454};
   double Ksat_set[]     = {0.446, 0.0743, 0.415};
  
   // Get the initial values set through the config file
   model_calib.GetValue("smcmax", &smcmax[0]);
-  model_calib.GetValue("van_genuchten_m", &vg_m[0]);
+  model_calib.GetValue("van_genuchten_n", &vg_n[0]);
   model_calib.GetValue("van_genuchten_alpha", &vg_alpha[0]);
   model_calib.GetValue("hydraulic_conductivity", &Ksat[0]);
   
   for (int i=0; i < num_layers; i++)
     std::cout<<"| Initial values: layer = "<< i+1 <<", smcmax = "<< smcmax[i]
-	     <<", vg_m = "<< vg_m[i] <<", vg_alpha = " << vg_alpha[i]
+	     <<", vg_n = "<< vg_n[i] <<", vg_alpha = " << vg_alpha[i]
 	     <<", Ksat = "<< Ksat[i] <<"\n";
 
   // set the new values
   model_calib.SetValue("smcmax", &smcmax_set[0]);
-  model_calib.SetValue("van_genuchten_m", &vg_m_set[0]);
+  model_calib.SetValue("van_genuchten_n", &vg_n_set[0]);
   model_calib.SetValue("van_genuchten_alpha", &vg_alpha_set[0]);
   model_calib.SetValue("hydraulic_conductivity", &Ksat_set[0]);
  
   // get the new/updated values
   model_calib.GetValue("smcmax", &smcmax[0]);
-  model_calib.GetValue("van_genuchten_m", &vg_m[0]);
+  model_calib.GetValue("van_genuchten_n", &vg_n[0]);
   model_calib.GetValue("van_genuchten_alpha", &vg_alpha[0]);
   model_calib.GetValue("hydraulic_conductivity", &Ksat[0]);
  
@@ -621,9 +621,9 @@ int main(int argc, char *argv[])
       throw std::runtime_error(errMsg.str());
     }
     
-    if (fabs(vg_m[i]  - vg_m_set[i]) > 1.E-5) {
+    if (fabs(vg_n[i]  - vg_n_set[i]) > 1.E-5) {
       std::stringstream errMsg;
-      errMsg << "Mismatch between vg_m calibrated values set and get "<< vg_m_set[i]<<" "<< vg_m[i]
+      errMsg << "Mismatch between vg_n calibrated values set and get "<< vg_n_set[i]<<" "<< vg_n[i]
 	     << " which is unexpected. \n";
       throw std::runtime_error(errMsg.str());
     }
@@ -647,7 +647,7 @@ int main(int argc, char *argv[])
   std::cout<<"|  \n";
   for (int i=0; i < num_layers; i++)
     std::cout<<"| Calib. values: layer = "<< i+1 <<", smcmax = "<< smcmax[i]
-	     <<", vg_m = "<< vg_m[i] <<", vg_alpha = " << vg_alpha[i]
+	     <<", vg_n = "<< vg_n[i] <<", vg_alpha = " << vg_alpha[i]
 	     <<", Ksat = "<< Ksat[i] <<"\n";
   std::cout<<"| *************************************** \n";
   std::cout<<"| LASAM Calibration test passed? YES \n";


### PR DESCRIPTION

[Short description explaining the high-level reason for the pull request]

## Additions
In this PR, LASAM has been mildly refactored in order to have the field capacity be a user-specified parameter in the config file, in the same style as wilting point. I also updated the calibratable params list in bmi_lgar.hxx to include field capacity, as well as max ponded head. I also edited that list to not include vg_m and instead use vg_n, because the parameters file provides n rather than m.
-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
