### PR TITLE
Update BMI C++ header to match upstream with virtual dtor and correct namespace

### DIFF
--- a/bmi/bmi.hxx
+++ b/bmi/bmi.hxx
@@ -9,10 +9,10 @@
 #include <string>
 #include <vector>
 
-namespace bmixx {
+namespace bmi {
 
-  //const int BMI_SUCCESS = 0;
-  //  const int BMI_FAILURE = 1;
+  const int BMI_SUCCESS = 0;
+  const int BMI_FAILURE = 1;
 
   const int MAX_COMPONENT_NAME = 2048;
   const int MAX_VAR_NAME = 2048;
@@ -21,6 +21,8 @@ namespace bmixx {
 
   class Bmi {
     public:
+      virtual ~Bmi() { }
+
       // Model control functions.
       virtual void Initialize(std::string config_file) = 0;
       virtual void Update() = 0;

--- a/include/bmi_lgar.hxx
+++ b/include/bmi_lgar.hxx
@@ -27,7 +27,7 @@ class NotImplemented : public std::logic_error {
 
 }
 
-class BmiLGAR : public bmixx::Bmi {
+class BmiLGAR : public bmi::Bmi {
 public:
   BmiLGAR() {
     this->input_var_names[0] = "precipitation_rate";


### PR DESCRIPTION
Cf NOAA-OWP/ngen#831 for the reasoning behind the virtual destructor inspiring the update.

The namespace change is to address the technicality that `bmi::Bmi*` is not actually equivalent to `bmixx::Bmi*`, even though the class definitions may be identical, and that difference technically entails Undefined Behavior when they're conflated in ngen.

## Changes

- Update the definition of the base `class Bmi` to match upstream with its virtual destructor
- Use the same `namespace bmi` as upstream, and not a custom `namespace bmixx` to avoid UB

## Testing

1. CI

## Notes

- There's no automatic tests in ngen that reference LGAR-C/LASAM, so nothing will immediately break by merging this in an uncoordinated fashion. Having this work may require use of an updated ngen with NOAA-OWP/ngen#832 integrated

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
