### PR TITLE
fix_giuh_array_water

### DIFF
--- a/include/all.hxx
+++ b/include/all.hxx
@@ -36,7 +36,7 @@ extern string verbosity;
 #define use_bmi_flag FALSE       // TODO set to TRUE to run in BMI environment
 
 #define MAX_NUM_SOIL_LAYERS 4
-#define MAX_NUM_SOIL_TYPES 16
+#define MAX_NUM_SOIL_TYPES 15
 #define MAX_SOIL_NAME_CHARS 25
 #define MAX_NUM_WETTING_FRONTS 300
 

--- a/src/lgar.cxx
+++ b/src/lgar.cxx
@@ -787,12 +787,6 @@ ReadVectorData(string key)
 
   if (z1.find(delimiter) == string::npos) {
     double v = stod(z1);
-    if (v == 0.0) {
-      stringstream errMsg;
-      errMsg << "soil_z (depth of soil reservior) should be greater than zero. It it set to "<< v << " in the config file "<< "\n";
-      throw runtime_error(errMsg.str());
-    }
-
     value.push_back(v);
 
   }

--- a/src/lgar.cxx
+++ b/src/lgar.cxx
@@ -890,29 +890,29 @@ extern void lgar_global_mass_balance(struct model_state *state, double *giuh_run
   
   //check if the giuh queue have some water left at the end of simulaiton; needs to be included in the global mass balance
   // hold on; this is probably not needed as we have volrunoff in the balance; revist AJK
-  for(int i=1; i <= state->lgar_bmi_params.num_giuh_ordinates; i++)
+  for(int i=0; i <= state->lgar_bmi_params.num_giuh_ordinates; i++)
     volend_giuh_cm += giuh_runoff_queue_cm[i];
 
-
   double global_error_cm = volstart + volprecip - volrunoff - volAET - volon - volrech - volend + volchange_calib_cm;
-
- printf("\n********************************************************* \n");
- printf("-------------------- Simulation Summary ----------------- \n");
- //printf("Time (sec)                 = %6.10f \n", elapsed);
- printf("------------------------ Mass balance ------------------- \n");
- printf("Initial water in soil     = %14.10f cm\n", volstart);
- printf("Total precipitation       = %14.10f cm\n", volprecip);
- printf("Total infiltration        = %14.10f cm\n", volin);
- printf("Final water in soil       = %14.10f cm\n", volend);
- printf("Surface ponded water      = %14.10f cm\n", volon);
- printf("Surface runoff            = %14.10f cm\n", volrunoff);
- printf("GIUH runoff               = %14.10f cm\n", volrunoff_giuh);
- printf("Total percolation         = %14.10f cm\n", volrech);
- printf("Total AET                 = %14.10f cm\n", volAET);
- printf("Total PET                 = %14.10f cm\n", volPET);
- printf("Total discharge (Q)       = %14.10f cm\n", total_Q_cm);
- printf("Vol change (calibration)  = %14.10f cm\n", volchange_calib_cm);
- printf("Global balance            =   %.6e cm\n", global_error_cm);
+  
+  printf("\n********************************************************* \n");
+  printf("-------------------- Simulation Summary ----------------- \n");
+  //printf("Time (sec)                 = %6.10f \n", elapsed);
+  printf("------------------------ Mass balance ------------------- \n");
+  printf("Initial water in soil     = %14.10f cm\n", volstart);
+  printf("Total precipitation       = %14.10f cm\n", volprecip);
+  printf("Total infiltration        = %14.10f cm\n", volin);
+  printf("Final water in soil       = %14.10f cm\n", volend);
+  printf("Surface ponded water      = %14.10f cm\n", volon);
+  printf("Surface runoff            = %14.10f cm\n", volrunoff);
+  printf("GIUH runoff               = %14.10f cm\n", volrunoff_giuh);
+  printf("GIUH water (in array)     = %14.10f cm\n", volend_giuh_cm);
+  printf("Total percolation         = %14.10f cm\n", volrech);
+  printf("Total AET                 = %14.10f cm\n", volAET);
+  printf("Total PET                 = %14.10f cm\n", volPET);
+  printf("Total discharge (Q)       = %14.10f cm\n", total_Q_cm);
+  printf("Vol change (calibration)  = %14.10f cm\n", volchange_calib_cm);
+  printf("Global balance            =   %.6e cm\n", global_error_cm);
 
 }
 

--- a/tests/configs/config_lasam_synth_1.txt
+++ b/tests/configs/config_lasam_synth_1.txt
@@ -10,4 +10,4 @@ layer_soil_type=13,14,15
 max_valid_soil_types=25
 wilting_point_psi=15495.0[cm]
 field_capacity_psi=340.9[cm]
-giuh_ordinates=0.0,0.0,0.0,0.0,0.0
+giuh_ordinates=0.0

--- a/tests/configs/config_lasam_synth_2.txt
+++ b/tests/configs/config_lasam_synth_2.txt
@@ -10,4 +10,4 @@ layer_soil_type=13,14,15
 max_valid_soil_types=25
 wilting_point_psi=15495.0[cm]
 field_capacity_psi=340.9[cm]
-giuh_ordinates=0.0,0.0,0.0,0.0,0.0
+giuh_ordinates=0.0


### PR DESCRIPTION
The PR fixed two bugs related to not accurately computing the leftover water in the GIUH array at the end of simulation, and in reading the giuh ordinates. No Changes to functionality.

## Additions
- None

## Removals 
- None

## Changes
- bug fixes

## Testing
1. All existing tests pass

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: