### PR TITLE
fix(bmi): Update(): Advance model time in early-return case for invalid soil type

### DIFF
--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -126,6 +126,7 @@ Update()
 
   double mm_to_cm = 0.1; // unit conversion
   double mm_to_m = 0.001;
+  double hr_to_sec = 3600;
   
   if (state->lgar_bmi_params.is_invalid_soil_type) {
     // add to mass balance accumulated variables
@@ -156,6 +157,9 @@ Update()
     bmi_unit_conv.volQ_CR_timestep_m    = 0.0;
     bmi_unit_conv.volPET_timestep_m     = 0.0;
     bmi_unit_conv.volrunoff_giuh_timestep_m = 0.0;
+
+    state->lgar_bmi_params.time_s += state->lgar_bmi_params.forcing_resolution_h * hr_to_sec;
+    state->lgar_bmi_params.timesteps++;
 
     return;
   }


### PR DESCRIPTION
In the case where CASAM saw an invalid soil type and returned early from `Bmi::Update()`, the failure to advance the model's current time confused ngen. It would look at the return value from `GetCurrentTime()`, see 0, and try to obtain forcing values for the corresponding point in time, not the overall simulation's time matching the timestep index. This was revealed by horrendously bad performance observed when running CASAM vs other formulations, and seeing massively more time spent reading forcing data, because the older values being requested conflicted with forcing cache contents and caused thrashing.

## Changes

- Advance model timestep by the value of `GetTimeStep()`, the `forcing_resolution_h` parameter in the invalid soil type early-return case

## Testing

1. Run model manually for offending catchments and observe values of `GetCurrentTime()` advancing in lock-step with other models making up the formulation

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: