### PR TITLE
fixing an error where the index of soil_type was just the wetting fro…

### DIFF
--- a/src/lgar.cxx
+++ b/src/lgar.cxx
@@ -1609,11 +1609,10 @@ extern double lgar_move_wetting_fronts(double timestep_h, double *free_drainage_
     if (wf == 1) { 
 
       wf_free_drainage_demand = wetting_front_free_drainage(*head);
-    // if ((wf == wf_free_drainage_demand) && (current->theta>=theta_e) ) {
-      int soil_num_k1  = soil_type[wf_free_drainage_demand];
-      double theta_e_k1 = soil_properties[soil_num_k1].theta_e;
-
       struct wetting_front *wf_free_drainage = listFindFront(wf_free_drainage_demand, *head, NULL);
+    // if ((wf == wf_free_drainage_demand) && (current->theta>=theta_e) ) {
+      int soil_num_k1  = soil_type[wf_free_drainage->layer_num];
+      double theta_e_k1 = soil_properties[soil_num_k1].theta_e;
 
       double mass_timestep = (old_mass + precip_mass_to_add) - (actual_ET_demand + free_drainage_demand + mass_correction_for_cached_free_drainage_fluxes);
 


### PR DESCRIPTION
…nt number of the wetting front responsible for free drainage, rather than that the soil layer of that wetting front

In the case of correcting the mass of the top wetting front in the event of saturation, the index of soil_type was just the front number of the wetting front responsible for free drainage. This WF number can actually take any integer value technically, whereas the index of soil_type should be a soil layer, in this case the soil layer that the free drainage WF is in. This PR corrects that. I also checked to make sure similar issues with soil_type indices were not happening anywhere else. 

## Additions

-

## Removals

-

## Changes

-soil_type now always has an index of a layer number rather than a WF number

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
