### PR TITLE
attempted to fix issue 50, where a layer_soil_type greater than the ma…

### DIFF
--- a/include/all.hxx
+++ b/include/all.hxx
@@ -401,7 +401,7 @@ extern double calc_storage_in_free_drainage_wetting_front(int wf_free_drainage, 
 extern void lgar_initialize(string config_file, struct model_state *state);
 extern void InitFromConfigFile(string config_file, struct model_state *state);
 extern vector<double> ReadVectorData(string key);
-extern void InitializeWettingFronts(int num_layers, double initial_psi_cm, int *layer_soil_type, double *cum_layer_thickness_cm,
+extern void InitializeWettingFronts(bool is_invalid_soil_type, int num_layers, double initial_psi_cm, int *layer_soil_type, double *cum_layer_thickness_cm,
 				    double *frozen_factor, struct wetting_front** head, struct soil_properties_ *soil_properties);
 
 /********************************************************************/

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -76,6 +76,21 @@ Initialize (std::string config_file)
     this->state = new model_state;
     state->head = NULL;
     state->state_previous = NULL;
+
+    state->soil_properties = NULL;
+
+    state->lgar_bmi_params.soil_depth_wetting_fronts = NULL;
+    state->lgar_bmi_params.soil_moisture_wetting_fronts = NULL;
+    state->lgar_bmi_params.soil_temperature = NULL;
+    state->lgar_bmi_params.soil_temperature_z = NULL;
+    state->lgar_bmi_params.layer_soil_type = NULL;
+    state->lgar_bmi_params.layer_thickness_cm = NULL;
+    state->lgar_bmi_params.cum_layer_thickness_cm = NULL;
+    state->lgar_bmi_params.giuh_ordinates = NULL;
+    state->lgar_bmi_params.frozen_factor = NULL;
+
+    state->lgar_bmi_input_params = NULL;
+
     lgar_initialize(config_file, state);
   }
 
@@ -156,6 +171,9 @@ Update()
     bmi_unit_conv.volQ_CR_timestep_m    = 0.0;
     bmi_unit_conv.volPET_timestep_m     = 0.0;
     bmi_unit_conv.volrunoff_giuh_timestep_m = 0.0;
+
+    state->lgar_bmi_params.time_s += state->lgar_bmi_params.forcing_resolution_h * state->units.hr_to_sec;
+    state->lgar_bmi_params.timesteps++;
 
     return;
   }
@@ -239,7 +257,7 @@ Update()
   assert(state->lgar_bmi_input_params->PET_mm_per_h >=0.0);
 
   // adaptive time step is set 
-  if (adaptive_timestep) {
+  if (adaptive_timestep && !state->lgar_bmi_params.is_invalid_soil_type) { //when there is an invalid soil type Q is equal to precip so no subsetpping is needed
     subtimestep_h = state->lgar_bmi_params.forcing_resolution_h;
     if (state->lgar_bmi_input_params->precipitation_mm_per_h > 10.0 || volon_timestep_cm > 0.0 ) {
       subtimestep_h = state->lgar_bmi_params.minimum_timestep_h;  //case where precip > 1 cm/h, or there is ponded head from the last time step

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -257,7 +257,7 @@ Update()
   assert(state->lgar_bmi_input_params->PET_mm_per_h >=0.0);
 
   // adaptive time step is set 
-  if (adaptive_timestep && !state->lgar_bmi_params.is_invalid_soil_type) { //when there is an invalid soil type Q is equal to precip so no subsetpping is needed
+  if (adaptive_timestep && !state->lgar_bmi_params.is_invalid_soil_type) { //when there is an invalid soil type Q is equal to precip so no substepping is needed
     subtimestep_h = state->lgar_bmi_params.forcing_resolution_h;
     if (state->lgar_bmi_input_params->precipitation_mm_per_h > 10.0 || volon_timestep_cm > 0.0 ) {
       subtimestep_h = state->lgar_bmi_params.minimum_timestep_h;  //case where precip > 1 cm/h, or there is ponded head from the last time step

--- a/src/lgar.cxx
+++ b/src/lgar.cxx
@@ -963,14 +963,10 @@ extern void InitFromConfigFile(string config_file, struct model_state *state)
   for (int i=0; i <= state->lgar_bmi_params.num_layers; i++)
     state->lgar_bmi_params.frozen_factor[i] = 1.0;
 
-  if (!state->lgar_bmi_params.is_invalid_soil_type){
-    InitializeWettingFronts(state->lgar_bmi_params.num_layers, state->lgar_bmi_params.initial_psi_cm,
-          state->lgar_bmi_params.layer_soil_type, state->lgar_bmi_params.cum_layer_thickness_cm,
-          state->lgar_bmi_params.frozen_factor, &state->head, state->soil_properties);
-  }
-  else {
-    state->head = NULL;
-  }
+  state->head = NULL; //this will be updated if there are only valid soil types, but if there are any invalid soil types, it will remain null
+  InitializeWettingFronts(state->lgar_bmi_params.is_invalid_soil_type, state->lgar_bmi_params.num_layers, state->lgar_bmi_params.initial_psi_cm,
+        state->lgar_bmi_params.layer_soil_type, state->lgar_bmi_params.cum_layer_thickness_cm,
+        state->lgar_bmi_params.frozen_factor, &state->head, state->soil_properties);
   
   if (verbosity.compare("none") != 0) {
     std::cerr<<"--- Initial state/conditions --- \n";
@@ -1019,42 +1015,44 @@ extern void InitFromConfigFile(string config_file, struct model_state *state)
   from the prescribed psi value for each of the soil layers
 */
 // #############################################################################
-extern void InitializeWettingFronts(int num_layers, double initial_psi_cm, int *layer_soil_type, double *cum_layer_thickness_cm,
+extern void InitializeWettingFronts(bool is_invalid_soil_type, int num_layers, double initial_psi_cm, int *layer_soil_type, double *cum_layer_thickness_cm,
 				    double *frozen_factor, struct wetting_front** head, struct soil_properties_ *soil_properties)
 {
-  int soil;
-  int front = 0;
-  double Se, theta_init;
-  bool bottom_flag;
-  double Ksat_cm_per_h;
-  struct wetting_front *current;
+  if (!is_invalid_soil_type){
+    int soil;
+    int front = 0;
+    double Se, theta_init;
+    bool bottom_flag;
+    double Ksat_cm_per_h;
+    struct wetting_front *current;
 
-  for(int layer=1;layer<=num_layers;layer++) {
-    front++;
+    for(int layer=1;layer<=num_layers;layer++) {
+      front++;
 
-    soil = layer_soil_type[layer];
-    theta_init = calc_theta_from_h(initial_psi_cm,soil_properties[soil].vg_alpha_per_cm,
-				   soil_properties[soil].vg_m,soil_properties[soil].vg_n,
-				   soil_properties[soil].theta_e,soil_properties[soil].theta_r);
+      soil = layer_soil_type[layer];
+      theta_init = calc_theta_from_h(initial_psi_cm,soil_properties[soil].vg_alpha_per_cm,
+            soil_properties[soil].vg_m,soil_properties[soil].vg_n,
+            soil_properties[soil].theta_e,soil_properties[soil].theta_r);
 
-    if (verbosity.compare("high") == 0) {
-      printf("layer, theta, psi, alpha, m, n, theta_e, theta_r = %d, %6.6f, %6.6f, %6.6f, %6.6f, %6.6f, %6.6f, %6.6f \n",
-	     layer, theta_init, initial_psi_cm, soil_properties[soil].vg_alpha_per_cm, soil_properties[soil].vg_m,
-	     soil_properties[soil].vg_n,soil_properties[soil].theta_e,soil_properties[soil].theta_r);
+      if (verbosity.compare("high") == 0) {
+        printf("layer, theta, psi, alpha, m, n, theta_e, theta_r = %d, %6.6f, %6.6f, %6.6f, %6.6f, %6.6f, %6.6f, %6.6f \n",
+        layer, theta_init, initial_psi_cm, soil_properties[soil].vg_alpha_per_cm, soil_properties[soil].vg_m,
+        soil_properties[soil].vg_n,soil_properties[soil].theta_e,soil_properties[soil].theta_r);
+      }
+
+      // the next lines create the initial moisture profile
+      bottom_flag = true;  // all initial wetting fronts are in contact with the bottom of the layer they exist in
+      // NOTE: The listInsertFront function does lots of stuff.
+
+      current = listInsertFront(cum_layer_thickness_cm[layer],theta_init,front,layer,bottom_flag, head);
+
+      current->psi_cm = initial_psi_cm;
+      Se = calc_Se_from_theta(current->theta,soil_properties[soil].theta_e,soil_properties[soil].theta_r);
+
+      Ksat_cm_per_h = frozen_factor[layer] * soil_properties[soil].Ksat_cm_per_h;
+      current->K_cm_per_h = calc_K_from_Se(Se, Ksat_cm_per_h , soil_properties[soil].vg_m);  // cm/s
+
     }
-
-    // the next lines create the initial moisture profile
-    bottom_flag = true;  // all initial wetting fronts are in contact with the bottom of the layer they exist in
-    // NOTE: The listInsertFront function does lots of stuff.
-
-    current = listInsertFront(cum_layer_thickness_cm[layer],theta_init,front,layer,bottom_flag, head);
-
-    current->psi_cm = initial_psi_cm;
-    Se = calc_Se_from_theta(current->theta,soil_properties[soil].theta_e,soil_properties[soil].theta_r);
-
-    Ksat_cm_per_h = frozen_factor[layer] * soil_properties[soil].Ksat_cm_per_h;
-    current->K_cm_per_h = calc_K_from_Se(Se, Ksat_cm_per_h , soil_properties[soil].vg_m);  // cm/s
-
   }
 
 }

--- a/src/lgar.cxx
+++ b/src/lgar.cxx
@@ -80,80 +80,88 @@ using namespace std;
 // ############################################################################################
 extern void lgar_initialize(string config_file, struct model_state *state)
 {
-  int soil;
-  
   InitFromConfigFile(config_file, state);
-  state->lgar_bmi_params.shape[0] = state->lgar_bmi_params.num_layers;
-  state->lgar_bmi_params.shape[1] = state->lgar_bmi_params.num_wetting_fronts;
-
-  // initial number of wetting fronts are same are number of layers
-  state->lgar_bmi_params.num_wetting_fronts           = state->lgar_bmi_params.num_layers;
-  state->lgar_bmi_params.soil_depth_wetting_fronts    = new double[state->lgar_bmi_params.num_wetting_fronts];
-  state->lgar_bmi_params.soil_moisture_wetting_fronts = new double[state->lgar_bmi_params.num_wetting_fronts];
-
-  // initialize array for holding calibratable parameters
-  // calibratabale parameters are scalars now not arrays
-  // state->lgar_calib_params.theta_e  = new double[state->lgar_bmi_params.num_layers];
-  // state->lgar_calib_params.theta_r  = new double[state->lgar_bmi_params.num_layers];
-  // state->lgar_calib_params.vg_n     = new double[state->lgar_bmi_params.num_layers];
-  // state->lgar_calib_params.vg_alpha = new double[state->lgar_bmi_params.num_layers];
-  // state->lgar_calib_params.Ksat     = new double[state->lgar_bmi_params.num_layers];
-  
-  // initialize thickness/depth and soil moisture of wetting fronts (used for model coupling)
-  // also initialize calibratable parameters
-  state->lgar_calib_params.field_capacity_psi = state->lgar_bmi_params.field_capacity_psi_cm;
-  state->lgar_calib_params.ponded_depth_max = state->lgar_bmi_params.ponded_depth_max_cm;
-  state->lgar_calib_params.a = state->lgar_bmi_params.a;
-  state->lgar_calib_params.b = state->lgar_bmi_params.b;
-  state->lgar_calib_params.frac_to_CR = state->lgar_bmi_params.frac_to_CR;
-  state->lgar_calib_params.a_slow = state->lgar_bmi_params.a_slow;
-  state->lgar_calib_params.b_slow = state->lgar_bmi_params.b_slow;
-  state->lgar_calib_params.frac_slow = state->lgar_bmi_params.frac_slow;
-  state->lgar_calib_params.spf_factor = state->lgar_bmi_params.spf_factor;
-
-  struct wetting_front *current = state->head;
-  for (int i=0; i<state->lgar_bmi_params.num_wetting_fronts; i++) { // note that this only works because at init there is 1 WF per layer, otherwise get soil type from current
-    assert (current != NULL);
+  if (!state->lgar_bmi_params.is_invalid_soil_type){
+    int soil;
     
-    soil = state->lgar_bmi_params.layer_soil_type[i+1];
+    state->lgar_bmi_params.shape[0] = state->lgar_bmi_params.num_layers;
+    state->lgar_bmi_params.shape[1] = state->lgar_bmi_params.num_wetting_fronts;
 
-    state->lgar_bmi_params.soil_moisture_wetting_fronts[i] = current->theta;
-    state->lgar_bmi_params.soil_depth_wetting_fronts[i]    = current->depth_cm * state->units.cm_to_m;
+    // initial number of wetting fronts are same are number of layers
+    state->lgar_bmi_params.num_wetting_fronts           = state->lgar_bmi_params.num_layers;
+    state->lgar_bmi_params.soil_depth_wetting_fronts    = new double[state->lgar_bmi_params.num_wetting_fronts];
+    state->lgar_bmi_params.soil_moisture_wetting_fronts = new double[state->lgar_bmi_params.num_wetting_fronts];
 
-    // // we now handle calibration of layered parameters with scalars
-    // state->lgar_calib_params.theta_e[i]  = state->soil_properties[soil].theta_e;
-    // state->lgar_calib_params.theta_r[i]  = state->soil_properties[soil].theta_r;
-    // state->lgar_calib_params.vg_n[i]     = state->soil_properties[soil].vg_n;
-    // state->lgar_calib_params.vg_alpha[i] = state->soil_properties[soil].vg_alpha_per_cm;
-    // state->lgar_calib_params.Ksat[i]     = state->soil_properties[soil].Ksat_cm_per_h;
-
-    if (i==0){
-      state->lgar_calib_params.theta_e_1  = state->soil_properties[soil].theta_e;
-      state->lgar_calib_params.theta_r_1  = state->soil_properties[soil].theta_r;
-      state->lgar_calib_params.vg_n_1     = state->soil_properties[soil].vg_n;
-      state->lgar_calib_params.vg_alpha_1 = state->soil_properties[soil].vg_alpha_per_cm;
-      state->lgar_calib_params.Ksat_1     = state->soil_properties[soil].Ksat_cm_per_h;
-    }
-
-    if (i==1){
-      state->lgar_calib_params.theta_e_2  = state->soil_properties[soil].theta_e;
-      state->lgar_calib_params.theta_r_2  = state->soil_properties[soil].theta_r;
-      state->lgar_calib_params.vg_n_2     = state->soil_properties[soil].vg_n;
-      state->lgar_calib_params.vg_alpha_2 = state->soil_properties[soil].vg_alpha_per_cm;
-      state->lgar_calib_params.Ksat_2     = state->soil_properties[soil].Ksat_cm_per_h;
-    }
-
-    if (i==2){
-      state->lgar_calib_params.theta_e_3  = state->soil_properties[soil].theta_e;
-      state->lgar_calib_params.theta_r_3  = state->soil_properties[soil].theta_r;
-      state->lgar_calib_params.vg_n_3     = state->soil_properties[soil].vg_n;
-      state->lgar_calib_params.vg_alpha_3 = state->soil_properties[soil].vg_alpha_per_cm;
-      state->lgar_calib_params.Ksat_3     = state->soil_properties[soil].Ksat_cm_per_h;
-    }
+    // initialize array for holding calibratable parameters
+    // calibratabale parameters are scalars now not arrays
+    // state->lgar_calib_params.theta_e  = new double[state->lgar_bmi_params.num_layers];
+    // state->lgar_calib_params.theta_r  = new double[state->lgar_bmi_params.num_layers];
+    // state->lgar_calib_params.vg_n     = new double[state->lgar_bmi_params.num_layers];
+    // state->lgar_calib_params.vg_alpha = new double[state->lgar_bmi_params.num_layers];
+    // state->lgar_calib_params.Ksat     = new double[state->lgar_bmi_params.num_layers];
     
-    current = current->next;
+    // initialize thickness/depth and soil moisture of wetting fronts (used for model coupling)
+    // also initialize calibratable parameters
+    state->lgar_calib_params.field_capacity_psi = state->lgar_bmi_params.field_capacity_psi_cm;
+    state->lgar_calib_params.ponded_depth_max = state->lgar_bmi_params.ponded_depth_max_cm;
+    state->lgar_calib_params.a = state->lgar_bmi_params.a;
+    state->lgar_calib_params.b = state->lgar_bmi_params.b;
+    state->lgar_calib_params.frac_to_CR = state->lgar_bmi_params.frac_to_CR;
+    state->lgar_calib_params.a_slow = state->lgar_bmi_params.a_slow;
+    state->lgar_calib_params.b_slow = state->lgar_bmi_params.b_slow;
+    state->lgar_calib_params.frac_slow = state->lgar_bmi_params.frac_slow;
+    state->lgar_calib_params.spf_factor = state->lgar_bmi_params.spf_factor;
+
+    struct wetting_front *current = state->head;
+    for (int i=0; i<state->lgar_bmi_params.num_wetting_fronts; i++) { // note that this only works because at init there is 1 WF per layer, otherwise get soil type from current
+      assert (current != NULL);
+      
+      soil = state->lgar_bmi_params.layer_soil_type[i+1];
+
+      state->lgar_bmi_params.soil_moisture_wetting_fronts[i] = current->theta;
+      state->lgar_bmi_params.soil_depth_wetting_fronts[i]    = current->depth_cm * state->units.cm_to_m;
+
+      // // we now handle calibration of layered parameters with scalars
+      // state->lgar_calib_params.theta_e[i]  = state->soil_properties[soil].theta_e;
+      // state->lgar_calib_params.theta_r[i]  = state->soil_properties[soil].theta_r;
+      // state->lgar_calib_params.vg_n[i]     = state->soil_properties[soil].vg_n;
+      // state->lgar_calib_params.vg_alpha[i] = state->soil_properties[soil].vg_alpha_per_cm;
+      // state->lgar_calib_params.Ksat[i]     = state->soil_properties[soil].Ksat_cm_per_h;
+
+      if (i==0){
+        state->lgar_calib_params.theta_e_1  = state->soil_properties[soil].theta_e;
+        state->lgar_calib_params.theta_r_1  = state->soil_properties[soil].theta_r;
+        state->lgar_calib_params.vg_n_1     = state->soil_properties[soil].vg_n;
+        state->lgar_calib_params.vg_alpha_1 = state->soil_properties[soil].vg_alpha_per_cm;
+        state->lgar_calib_params.Ksat_1     = state->soil_properties[soil].Ksat_cm_per_h;
+      }
+
+      if (i==1){
+        state->lgar_calib_params.theta_e_2  = state->soil_properties[soil].theta_e;
+        state->lgar_calib_params.theta_r_2  = state->soil_properties[soil].theta_r;
+        state->lgar_calib_params.vg_n_2     = state->soil_properties[soil].vg_n;
+        state->lgar_calib_params.vg_alpha_2 = state->soil_properties[soil].vg_alpha_per_cm;
+        state->lgar_calib_params.Ksat_2     = state->soil_properties[soil].Ksat_cm_per_h;
+      }
+
+      if (i==2){
+        state->lgar_calib_params.theta_e_3  = state->soil_properties[soil].theta_e;
+        state->lgar_calib_params.theta_r_3  = state->soil_properties[soil].theta_r;
+        state->lgar_calib_params.vg_n_3     = state->soil_properties[soil].vg_n;
+        state->lgar_calib_params.vg_alpha_3 = state->soil_properties[soil].vg_alpha_per_cm;
+        state->lgar_calib_params.Ksat_3     = state->soil_properties[soil].Ksat_cm_per_h;
+      }
+      
+      current = current->next;
+    }
   }
-
+  else { // invalid soil type, so no WFs should be created and Q will be equal to precip
+    state->lgar_bmi_params.num_wetting_fronts = 0;
+    state->head = NULL;
+    state->lgar_bmi_params.ponded_depth_cm = 0.0;
+    state->lgar_bmi_params.time_s = 0.0;
+    state->lgar_bmi_params.timesteps = 0.0;
+  }
 
   /* initialize bmi input variables to -1.0 (on purpose), this should be assigned (non-negative) and if not,
      the code will throw an error in the Update method */
@@ -766,7 +774,7 @@ extern void InitFromConfigFile(string config_file, struct model_state *state)
   }
   
   if(!is_max_valid_soil_types_set)
-     state->lgar_bmi_params.num_soil_types = MAX_NUM_SOIL_TYPES;     // maximum number of valid soil types defaults to 15
+     state->lgar_bmi_params.num_soil_types = MAX_NUM_SOIL_TYPES;     // maximum number of valid soil types defaults to 25
 
   if (verbosity.compare("high") == 0) {
     std::cerr<<"Maximum number of soil types: "<<state->lgar_bmi_params.num_soil_types<<"\n";
@@ -794,8 +802,16 @@ extern void InitFromConfigFile(string config_file, struct model_state *state)
     state->soil_properties = new soil_properties_[state->lgar_bmi_params.num_soil_types+1];
     int num_soil_types = state->lgar_bmi_params.num_soil_types;
     double wilting_point_psi_cm = state->lgar_bmi_params.wilting_point_psi_cm;
-    lgar_read_vG_param_file(soil_params_file.c_str(), num_soil_types,
+    int num_soils_in_file = lgar_read_vG_param_file(soil_params_file.c_str(), num_soil_types,
 						    wilting_point_psi_cm, state->soil_properties, state->lgar_bmi_params.log_mode);
+
+    for (int layer=1; layer <= state->lgar_bmi_params.num_layers; layer++) {
+      if ((state->lgar_bmi_params.layer_soil_type[layer] > num_soils_in_file) && (state->lgar_bmi_params.layer_soil_type[layer]<=state->lgar_bmi_params.num_soil_types)){
+        std::cerr << "Soil type is less than max_valid_soil_types but is greater than the number of lines in the soil data file. \n";
+        std::cerr << "If you intend to include invalid soil types, then set max_valid_soil_types to be equal to the number of soil types in the soil data file and then include a layer_soil_type greater than that.";
+        abort();
+      }
+    }
 
     // check if soil layers provided are within the range
     state->lgar_bmi_params.is_invalid_soil_type = false; // model not valid for soil types = waterbody, glacier, lava, etc.
@@ -813,7 +829,7 @@ extern void InitFromConfigFile(string config_file, struct model_state *state)
       }
     }
 
-    if (verbosity.compare("high") == 0) {
+    if ((verbosity.compare("high") == 0) && (!state->lgar_bmi_params.is_invalid_soil_type)) {
       for (int layer=1; layer<=state->lgar_bmi_params.num_layers; layer++) {
 	int soil = state->lgar_bmi_params.layer_soil_type[layer];
 	std::cerr<<"Soil type/name : "<<state->lgar_bmi_params.layer_soil_type[layer]
@@ -947,9 +963,14 @@ extern void InitFromConfigFile(string config_file, struct model_state *state)
   for (int i=0; i <= state->lgar_bmi_params.num_layers; i++)
     state->lgar_bmi_params.frozen_factor[i] = 1.0;
 
-  InitializeWettingFronts(state->lgar_bmi_params.num_layers, state->lgar_bmi_params.initial_psi_cm,
-			  state->lgar_bmi_params.layer_soil_type, state->lgar_bmi_params.cum_layer_thickness_cm,
-			  state->lgar_bmi_params.frozen_factor, &state->head, state->soil_properties);
+  if (!state->lgar_bmi_params.is_invalid_soil_type){
+    InitializeWettingFronts(state->lgar_bmi_params.num_layers, state->lgar_bmi_params.initial_psi_cm,
+          state->lgar_bmi_params.layer_soil_type, state->lgar_bmi_params.cum_layer_thickness_cm,
+          state->lgar_bmi_params.frozen_factor, &state->head, state->soil_properties);
+  }
+  else {
+    state->head = NULL;
+  }
   
   if (verbosity.compare("none") != 0) {
     std::cerr<<"--- Initial state/conditions --- \n";
@@ -958,13 +979,23 @@ extern void InitFromConfigFile(string config_file, struct model_state *state)
   }
 
   // initial mass in the system
-  state->lgar_mass_balance.volstart_cm      = lgar_calc_mass_bal(state->lgar_bmi_params.cum_layer_thickness_cm, state->head);
+  if (!state->lgar_bmi_params.is_invalid_soil_type){
+    state->lgar_mass_balance.volstart_cm      = lgar_calc_mass_bal(state->lgar_bmi_params.cum_layer_thickness_cm, state->head);
+  }
+  else {
+    state->lgar_mass_balance.volstart_cm      = 0.0;
+  }
 
   state->lgar_bmi_params.ponded_depth_cm    = 0.0; // initially we start with a dry surface (no surface ponding)
   state->lgar_bmi_params.nint               = 120; // hacked, not needed to be an input option
   state->lgar_bmi_params.num_wetting_fronts = state->lgar_bmi_params.num_layers;
-
-  assert (state->lgar_bmi_params.num_layers == listLength(state->head));
+  if (state->lgar_bmi_params.is_invalid_soil_type){
+    state->lgar_bmi_params.num_wetting_fronts = 0;
+  }
+  else {
+    assert (state->lgar_bmi_params.num_layers == listLength(state->head));
+  }
+  
 
   if (verbosity.compare("high") == 0) {
     std::cerr<<"Initial ponded depth is set to zero. \n";


### PR DESCRIPTION
…x_valid_soil_types caused LGAR to try to initialize with soil types that did not exist

This PR fixes an issue where LGAR tried to initialize with soil types that did not exist -- now, when there is an invalid soil type, LGAR's initialization will not try to initialize parameters for individual soil layers. Also fixed an issue where the time step was not advanced in the case of an invalid soil type, and finally fixed an issue with high verbosity runs (will not try to print soil layer data when there is an invalid soil type)

## Additions

-Made it so that the time step advances even when the soil type is invalid
-Disabled substepping when invalid soil types are present because it is not necessary 
-The bulk of lgar_initialize now only runs when only valid soil types are present 
-Wetting fronts themselves only initialized when only valid soil types are present 

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
