### PR TITLE
Allocate memory for all BMI output variables, even if they're reported as empty

### DIFF
--- a/src/lgar.cxx
+++ b/src/lgar.cxx
@@ -161,6 +161,9 @@ extern void lgar_initialize(string config_file, struct model_state *state)
     state->lgar_bmi_params.ponded_depth_cm = 0.0;
     state->lgar_bmi_params.time_s = 0.0;
     state->lgar_bmi_params.timesteps = 0.0;
+    // Placeholder allocations so that BMI GetValuePtr doesn't return NULL for these variables
+    state->lgar_bmi_params.soil_depth_wetting_fronts = new double[1];
+    state->lgar_bmi_params.soil_moisture_wetting_fronts = new double[1];
   }
 
   /* initialize bmi input variables to -1.0 (on purpose), this should be assigned (non-negative) and if not,

--- a/src/lgar.cxx
+++ b/src/lgar.cxx
@@ -161,9 +161,12 @@ extern void lgar_initialize(string config_file, struct model_state *state)
     state->lgar_bmi_params.ponded_depth_cm = 0.0;
     state->lgar_bmi_params.time_s = 0.0;
     state->lgar_bmi_params.timesteps = 0.0;
+
     // Placeholder allocations so that BMI GetValuePtr doesn't return NULL for these variables
     state->lgar_bmi_params.soil_depth_wetting_fronts = new double[1];
     state->lgar_bmi_params.soil_moisture_wetting_fronts = new double[1];
+    state->lgar_bmi_params.soil_depth_wetting_fronts[0] = NAN;
+    state->lgar_bmi_params.soil_moisture_wetting_fronts[0] = NAN;
   }
 
   /* initialize bmi input variables to -1.0 (on purpose), this should be assigned (non-negative) and if not,


### PR DESCRIPTION
When the soil type is invalid, the BMI interface reports these variables as zero-size. However, ngen may still call `GetValuePtr`, and we don't want that to see a NULL pointer.

## Changes

- Make dummy allocations for the affected variables, and fill them with NaN so that misuse will be obvious

## Testing

1. Ran ngen over a single partition of the CONUS ensemble configuration, and saw no crashes for any of the 2,167 included catchments.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
