### PR TITLE
in the event that a fix dry over wet event occurs, we do not always want to …

### DIFF
--- a/include/all.hxx
+++ b/include/all.hxx
@@ -388,7 +388,7 @@ extern double lgar_theta_mass_balance(int layer_num, int soil_num, double psi_cm
 				      int *soil_type, struct soil_properties_ *soil_properties);
 
 // computes updated theta (soil moisture content) after fixing a dry over wet front or after layer boundary crossing to address edge cases 
-extern void lgar_theta_mass_balance_correction(int front_num, double prior_mass, struct wetting_front** head, double *cum_layer_thickness_cm, int *soil_type, struct soil_properties_ *soil_properties);
+extern void lgar_theta_mass_balance_correction(bool use_dry_over_wet, int front_num, double prior_mass, struct wetting_front** head, double *cum_layer_thickness_cm, int *soil_type, struct soil_properties_ *soil_properties);
 
 extern double calc_min_water_possible_for_free_drainage_wetting_front(int wf_free_drainage, struct wetting_front** head, int *soil_type, struct soil_properties_ *soil_properties);
 

--- a/src/lgar.cxx
+++ b/src/lgar.cxx
@@ -2095,7 +2095,7 @@ extern void lgar_wetting_fronts_cross_layer_boundary(int num_layers,
           current->depth_cm = cum_layer_thickness_cm[num_layers] + 1.E-6;
           int front_num_correction = current->front_num;
           // first, lgar_theta_mass_balance_correction will attempt to close the mass balance by adjusting the theta value of the WF that crossed the layer boundary and other WFs sharing a psi value with it.
-          lgar_theta_mass_balance_correction(front_num_correction, prior_mass, head, cum_layer_thickness_cm, soil_type, soil_properties); 
+          lgar_theta_mass_balance_correction(false, front_num_correction, prior_mass, head, cum_layer_thickness_cm, soil_type, soil_properties); 
             if (verbosity.compare("high") == 0) {
               printf("States after wetting fronts cross layer boundary and after theta correction...\n");
               listPrint(*head);
@@ -2285,7 +2285,7 @@ extern void lgar_fix_dry_over_wet_wetting_fronts(double *mass_change, double* cu
         double prior_mass = lgar_calc_mass_bal(cum_layer_thickness_cm, *head);
         current = listDeleteFront(current->front_num, head, soil_type, soil_properties); //current will be the WF directly after the one that got deleted
         int front_num_correction = current->front_num;
-        lgar_theta_mass_balance_correction(front_num_correction, prior_mass, head, cum_layer_thickness_cm, soil_type, soil_properties);
+        lgar_theta_mass_balance_correction(true, front_num_correction, prior_mass, head, cum_layer_thickness_cm, soil_type, soil_properties);
         double mass_after = lgar_calc_mass_bal(cum_layer_thickness_cm, *head);
         *mass_change += (mass_after - prior_mass);
 
@@ -3259,7 +3259,7 @@ extern double calc_storage_in_free_drainage_wetting_front(int wf_free_drainage, 
    lgar_theta_mass_balance because it does not need information about old WFs or external fluxes
    and is called far less often.*/
 // ############################################################################################
-extern void lgar_theta_mass_balance_correction(int front_num, double prior_mass, struct wetting_front** head, double *cum_layer_thickness_cm, int *soil_type, struct soil_properties_ *soil_properties){
+extern void lgar_theta_mass_balance_correction(bool use_dry_over_wet, int front_num, double prior_mass, struct wetting_front** head, double *cum_layer_thickness_cm, int *soil_type, struct soil_properties_ *soil_properties){
   struct wetting_front *current;
   current = listFindFront(front_num, *head, NULL);
 
@@ -3355,7 +3355,14 @@ extern void lgar_theta_mass_balance_correction(int front_num, double prior_mass,
 
     struct wetting_front *next = current->next;
     struct wetting_front *before_next = current;
-    if (next){ // current was previously selected as the top most WF in the region that we want to iteratively adjust. The lowest will be either the lowest WF, or the first WF below current that is not to_bottom.
+    bool skip_bottom_chain_below = false;
+    if (next){
+      skip_bottom_chain_below = use_dry_over_wet && next->to_bottom && !current->to_bottom;
+    }
+
+    if (next && !skip_bottom_chain_below){ // current was previously selected as the top most WF in the region that we want to iteratively adjust. The lowest will be either the lowest WF, or the first WF below current that is not to_bottom.
+      // use_dry_over_wet included because this function is generally used to correct "chains" of WFs that should have the same psi value across layers, including to_bottom WFs below the one that is being corrected. 
+      // In the case of fixing dry over wet WFs this is only desired if the WF being corrected is itself to_bottom. If it is not, it should not attempt to also include the next to_bottom WF in its mass update.
       double theta_e;
       double theta_r;
       double vg_a;


### PR DESCRIPTION
…include the mass of the to_bottom WF below the fixed WF in the mass update for fixing the WF. While the previous behavior would not cause a crash, it did lead to a sudden but small insertion of moisture at a large depth, which could increase free drainage in a subtle way.

Old behavior: in the event that there was a dry over wet event where the dry over wet pair was directly above a to_bottom WF, the to_bottom WF would be included in updating mass after the deleting the drier WF. Physically this would sometimes lead to inserting a small amount of water in that to_bottom WF, which then would increase free drainage if the to_bottom WF was also the WF at the bottom of the model domain. 

New behavior: for lgar_fix_dry_over_wet_wetting_fronts , we now make sure that the to_bottom WF below the dry-over-wet wetting front pair is not included in updating mass if the surviving WF from the dry-over-wet pair is not to_bottom. 

## Additions

-

## Removals

-

## Changes

-lgar_theta_mass_balance_correction will stop including WFs below the current one in its mass balance update if it is being called in lgar_fix_dry_over_wet_wetting_fronts, the next WF is to_bottom, and the current WF is not to_bottom

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
