### PR TITLE
fixed ponded head mass balance accounting error for when conceptual r…

### DIFF
--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -374,6 +374,7 @@ Update()
     state->state_previous = listCopy(state->head);
 
     double ponded_flux_for_CR = 0.0;
+    double volon_start_subtimestep_cm = volon_timestep_cm;
 
     // allocates some water to conceptual reservoir storage via conditional preferential flow
     if (state->lgar_bmi_params.runoff_in_prev_step){
@@ -720,7 +721,7 @@ Update()
     /*----------------------------------------------------------------------*/
     // mass balance at the subtimestep (local mass balance)
 
-    double local_mb = volstart_subtimestep_cm + precip_subtimestep_cm + volon_timestep_cm - volrunoff_subtimestep_cm - volQ_CR_subtimestep_cm - volCRend_subtimestep_cm + volCRstart_subtimestep_cm 
+    double local_mb = volstart_subtimestep_cm + precip_subtimestep_cm + volon_start_subtimestep_cm - volrunoff_subtimestep_cm - volQ_CR_subtimestep_cm - volCRend_subtimestep_cm + volCRstart_subtimestep_cm 
                       - AET_subtimestep_cm - volon_subtimestep_cm - volrech_subtimestep_cm - volend_subtimestep_cm;
 
 

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -393,6 +393,7 @@ Update()
     state->state_previous = listCopy(state->head);
 
     double ponded_flux_for_CR = 0.0;
+    double volon_start_subtimestep_cm = volon_timestep_cm;
 
     // allocates some water to conceptual reservoir storage via conditional preferential flow
     if (state->lgar_bmi_params.runoff_in_prev_step){
@@ -742,7 +743,7 @@ Update()
     /*----------------------------------------------------------------------*/
     // mass balance at the subtimestep (local mass balance)
 
-    double local_mb = volstart_subtimestep_cm + precip_subtimestep_cm + volon_timestep_cm - volrunoff_subtimestep_cm - volQ_CR_subtimestep_cm - volCRend_subtimestep_cm + volCRstart_subtimestep_cm 
+    double local_mb = volstart_subtimestep_cm + precip_subtimestep_cm + volon_start_subtimestep_cm - volrunoff_subtimestep_cm - volQ_CR_subtimestep_cm - volCRend_subtimestep_cm + volCRstart_subtimestep_cm 
                       - AET_subtimestep_cm - volon_subtimestep_cm - volrech_subtimestep_cm - interflow_subtimestep_cm - volend_subtimestep_cm;
 
 


### PR DESCRIPTION
…eservoir is enabled and ponded head is allowed to be greater than 0

When a nonlinear reservoir is enabled and ponded_depth_max is set to greater than 0, fixed mass balance accounting. 


To reproduce old error: 
Change configs/config_lasam_Bushland.txt such that: 

`mbal_tol=0.001`
`ponded_depth_max=2[cm]`

you will get a mass balance error. In the new branch you will not. 

There are no changes to the simulated wetting fronts or model outputs, this fix is purely a mass balance accounting error. (You can actually see this in the identical model summaries if you leave out the mbal_tol line in the config.) So both the old and new simulations should be the same except for the substep mass balance accounting.


In particular, what was going wrong: 

When `ponded_depth_max > 0`, ponded water can be carried into the next substep as `volon_timestep_cm`. If preferential flow to the conceptual reservoir is active on that substep, the code partitions both precipitation and existing ponded water: a fraction is routed to the conceptual reservoir, and `volon_timestep_cm` is reduced to the fraction that remains on at the surface. So far so good. 

The issue: the old local mass balance check used this already-reduced `volon_timestep_cm` as the initial ponded water storage term, meaning it missed the fraction that went to the reservoir. So it undercounted the water present at the start of the substep, while the conceptual reservoir storage/outflow terms still accounted for the fraction routed to the reservoir. As a result, the model could report a false substep mass balance error and abort. 


## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
