### PR TITLE
adding dual reservoir calibratable parameters

### DIFF
--- a/include/bmi_lgar.hxx
+++ b/include/bmi_lgar.hxx
@@ -88,7 +88,9 @@ public:
     this->calib_var_names[9]  = "b";
     this->calib_var_names[10] = "frac_to_CR";
     this->calib_var_names[11] = "spf_factor";
-
+    this->calib_var_names[12] = "a_slow";
+    this->calib_var_names[13] = "b_slow";
+    this->calib_var_names[14] = "frac_slow";
 
   };
   
@@ -153,7 +155,7 @@ private:
   struct model_state* state;
   static const int input_var_name_count  = 3;
   static const int output_var_name_count = 15;
-  static const int calib_var_name_count  = 12;
+  static const int calib_var_name_count  = 15;
   
   std::string input_var_names[input_var_name_count];
   std::string output_var_names[output_var_name_count];

--- a/include/bmi_lgar.hxx
+++ b/include/bmi_lgar.hxx
@@ -77,20 +77,23 @@ public:
 
     // //calibratable parameters have been updated to reflect those used in broad testing, which used a 2 layer instance of LGAR. Edits to this list are absolutely possible.
     this->calib_var_names[0]  = "smcmax_1";
-    this->calib_var_names[1]  = "van_genuchten_n_1";
-    this->calib_var_names[2]  = "van_genuchten_alpha_1";
-    this->calib_var_names[3]  = "hydraulic_conductivity_1";
-    this->calib_var_names[4]  = "van_genuchten_n_2";
-    this->calib_var_names[5]  = "van_genuchten_alpha_2";
-    this->calib_var_names[6]  = "hydraulic_conductivity_2";
-    this->calib_var_names[7]  = "field_capacity";
-    this->calib_var_names[8]  = "a";
-    this->calib_var_names[9]  = "b";
-    this->calib_var_names[10] = "frac_to_CR";
-    this->calib_var_names[11] = "spf_factor";
-    this->calib_var_names[12] = "a_slow";
-    this->calib_var_names[13] = "b_slow";
-    this->calib_var_names[14] = "frac_slow";
+    this->calib_var_names[1]  = "smcmin_1";
+    this->calib_var_names[2]  = "van_genuchten_n_1";
+    this->calib_var_names[3]  = "van_genuchten_alpha_1";
+    this->calib_var_names[4]  = "hydraulic_conductivity_1";
+    this->calib_var_names[5]  = "smcmax_2";
+    this->calib_var_names[6]  = "smcmin_2";
+    this->calib_var_names[7]  = "van_genuchten_n_2";
+    this->calib_var_names[8]  = "van_genuchten_alpha_2";
+    this->calib_var_names[9]  = "hydraulic_conductivity_2";
+    this->calib_var_names[10] = "field_capacity";
+    this->calib_var_names[11] = "a";
+    this->calib_var_names[12] = "b";
+    this->calib_var_names[13] = "frac_to_CR";
+    this->calib_var_names[14] = "spf_factor";
+    this->calib_var_names[15] = "a_slow";
+    this->calib_var_names[16] = "b_slow";
+    this->calib_var_names[17] = "frac_slow";
 
   };
   
@@ -155,7 +158,7 @@ private:
   struct model_state* state;
   static const int input_var_name_count  = 3;
   static const int output_var_name_count = 15;
-  static const int calib_var_name_count  = 15;
+  static const int calib_var_name_count  = 18;
   
   std::string input_var_names[input_var_name_count];
   std::string output_var_names[output_var_name_count];


### PR DESCRIPTION
Adds the capacity to calibrate dual reservoir parameters. Preliminary testing indicates that including the second reservoir only improves calibration in a handful of basins compared to CASAM with one reservoir, and might lead to more equifinality problems via more calibrated parameters. Nonetheless, including the second reservoir is not mandatory, and it can probably improve the model in some catchments. 

Also adding residual water content as a calibratable parameter for soil layers 1 and 2, as well as effective saturated water content for layer 2.

## Additions

-a_slow, b_slow, and frac_slow, smcmax_2, smcmin_1, smcmin_2 now in calibratable parameters list 

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
