### PR TITLE
fix: parsing of soil type name from soil table file.

### DIFF
--- a/include/all.hxx
+++ b/include/all.hxx
@@ -37,7 +37,7 @@ extern string verbosity;
 
 #define MAX_NUM_SOIL_LAYERS 4
 #define MAX_NUM_SOIL_TYPES 25 //changed back to 25 from 15, because the file that loads soil types for Bushland relies on entries 16, 17, and 18 in the .dat file.
-#define MAX_SOIL_NAME_CHARS 25
+#define MAX_SOIL_NAME_CHARS 30
 #define MAX_NUM_WETTING_FRONTS 300
 
 

--- a/src/lgar.cxx
+++ b/src/lgar.cxx
@@ -3207,7 +3207,7 @@ extern int lgar_read_vG_param_file(char const* vG_param_file_name, int num_soil_
   // local vars
   FILE *in_vG_params_fptr = NULL;
   char jstr[256];
-  char soil_name[30];
+  char soil_name[MAX_SOIL_NAME_CHARS];
   // bool error;
   int length;
   int num_soils_in_file = 0;             // soil counter
@@ -3225,14 +3225,34 @@ extern int lgar_read_vG_param_file(char const* vG_param_file_name, int num_soil_
   //for(soil=1;soil<=num_soil_types;soil++) {// read the num_soil_types lines with data
   while (fgets(jstr,255,in_vG_params_fptr) != NULL) {
 
-    sscanf(jstr,"%s %lf %lf %lf %lf %lf",soil_name,&theta_r,&theta_e,&vg_alpha_per_cm,&vg_n,&Ksat_cm_per_h);
-    length=strlen(soil_name);
+    // The soil name must be double-quoted and may contain spaces (e.g. "Sandy-clay loam"),
+    // so it cannot be read with a %s conversion, which stops at the first space.
+    char *cp = jstr;
+    length = 0;
+    // soil type names must be quoted
+    if (*cp != '"') {
+        printf("van Genuchten parameter file soil type names must be quoted.");
+        exit(-1);
+    }
+    cp++; // skip the opening quote
+    while (*cp != '"' && *cp != '\n' && length < MAX_SOIL_NAME_CHARS-1){
+	    soil_name[length] = *cp;
+        length++;
+        cp++;
+    }
+    if (*cp != '"') {
+	printf("While reading vG soil parameter file: %s, soil name unterminated quote or longer than allowed.\n",
+	       vG_param_file_name);
+	exit(-1);
+    }
+    cp++; // skip the closing quote
+    soil_name[length] = '\0';
 
-    if(length>MAX_SOIL_NAME_CHARS) {
-      printf("While reading vG soil parameter file: %s, soil name longer than allowed.  Increase MAX_SOIL_NAME_CHARS\n",
-	     vG_param_file_name);
-      printf("Program stopped.\n");
-      exit(0);
+    if (sscanf(cp,"%lf %lf %lf %lf %lf",&theta_r,&theta_e,&vg_alpha_per_cm,&vg_n,&Ksat_cm_per_h) != 5) {
+      printf("While reading vG soil parameter file: %s, soil %s: expected 5 numeric values after the soil name.\n"
+             "theta_r theta_e vg_alpha_per_cm vg_n Ksat_cm_per_h\n",
+	     vG_param_file_name, soil_name);
+      exit(-1);
     }
 
     strcpy(soil_properties[soil].soil_name,soil_name);


### PR DESCRIPTION
`lgar_read_vG_param_file` parsed each row with `sscanf("%s %lf ...")`, which breaks on quoted soil names containing spaces (e.g. "Sandy-clay loam"). `%s` stops at the first space. Because the return value was unchecked, the row silently inherited the previous row's numeric values.

The effects of this are best shown with `log_mode=true`. Stale `alpha`/`Ksat` are re-exponentiated once per failed row, compounding into nonsense (`alpha` `~3.6e10`, `Ksat = inf`) that initialized wetting fronts with `K = nan` and eventually produced nan discharge values.

Aside, this also addresses an out of bounds memory copy in `lgar_read_vG_param_file`. It was possible that a soil type name was successfully parsed into a buffer larger than the soil_properties_ buffer it is later copied into.

## Changes

- require soil type names to be double-quoted and parse them up to the closing quote, so names with embedded spaces are read correctly
- read the five numeric fields with a checked `sscanf` and abort with a clear error naming the file and soil on any malformed row
- error out on unterminated/overlong names instead of overflowing; bump `MAX_SOIL_NAME_CHARS` to 30 and size the local buffer with it