### PR TITLE
Fix layered calibration with duplicate soil types in the context of ngen cal

### DIFF
--- a/src/lgar.cxx
+++ b/src/lgar.cxx
@@ -860,7 +860,7 @@ extern void InitFromConfigFile(string config_file, struct model_state *state)
     //state->soil_properties = (struct soil_properties_*) malloc((state->lgar_bmi_params.num_layers+1)*sizeof(struct soil_properties_));
 
 
-    state->soil_properties = new soil_properties_[state->lgar_bmi_params.num_soil_types+1];
+    state->soil_properties = new soil_properties_[state->lgar_bmi_params.num_soil_types + state->lgar_bmi_params.num_layers + 1];
     int num_soil_types = state->lgar_bmi_params.num_soil_types;
     double wilting_point_psi_cm = state->lgar_bmi_params.wilting_point_psi_cm;
     int num_soils_in_file = lgar_read_vG_param_file(soil_params_file.c_str(), num_soil_types,
@@ -897,6 +897,16 @@ extern void InitFromConfigFile(string config_file, struct model_state *state)
 		 <<" "<<state->soil_properties[soil].soil_name<<"\n";
       }
       std::cerr<<"          *****         \n";
+    }
+
+    // Give calibrating layers private records so duplicate textural classes do not conflict.
+    if (state->lgar_bmi_params.calib_params_flag && !state->lgar_bmi_params.is_invalid_soil_type) {
+      for (int layer=1; layer<=state->lgar_bmi_params.num_layers; layer++) {
+        int source = state->lgar_bmi_params.layer_soil_type[layer];
+        int target = state->lgar_bmi_params.num_soil_types + layer;
+        state->soil_properties[target] = state->soil_properties[source];
+        state->lgar_bmi_params.layer_soil_type[layer] = target;
+      }
     }
   }
   else {


### PR DESCRIPTION

This PR fixes layered calibration when multiple soil layers begin calibration with the same textural class, for example:

    layer_soil_type=6,6

Previously, both layers referenced the same `soil_properties` record. So, calibration updates intended for one layer could overwrite values assigned to another layer. This compromised calibration of the per layer hydraulic parameters and often caused a mass balance error.


## Additions

- Allocate a private `soil_properties` record for each soil layer when calibration mode is enabled and the used soil types are valid.
- Initialize each private record from the layer’s configured textural class.

## Removals

-

## Changes

-

## Testing

1. Verified that two layers configured as `layer_soil_type=6,6` start with identical properties but can retain independently assigned `alpha`, `Ksat`, and `n` values.
2. Verified that duplicate invalid soil types, including `13,13` and `14,14`, retain the existing invalid-soil behavior.
3. Ran the existing `lasam_unitest`.
4. Ran the Phillipsburg and Bushland standalone simulations and checked their final mass balances.
5. Completed a four-iteration ngen-cal DDS run using two layers configured as `layer_soil_type=6,6`, including hydraulic calibration parameters for both layers.

## Screenshots


## Notes

- No configuration changes are required.
- Behavior is unchanged when calibration mode is disabled.
- Existing invalid soil type handling is unchanged.

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
